### PR TITLE
Create hcp-eks-demo and submodule hcp-eks-client

### DIFF
--- a/examples/hcp-eks-demo/README.md
+++ b/examples/hcp-eks-demo/README.md
@@ -1,0 +1,28 @@
+## HCP EKS Demo
+
+This Terraform example stands up a full deployment of a HCP Consul cluster
+connected to an AWS EKS cluster.
+
+### Prerequisites
+
+1. Create a HCP Service Key and set the required environment variables
+
+```
+export HCP_CLIENT_ID=...
+export HCP_CLIENT_SECRET=...
+```
+
+2. Export your AWS Account credentials, as defined by the AWS Terraform provider
+
+3. Initialize and apply the Terraform configuration
+
+```
+terraform init && terraform apply
+```
+
+4. The provisioned Consul cluster can be accessed via the outputs `consul_url`
+   and `consul_root_token`
+
+5. The provisioned EKS cluster can be accessed via the output
+   `kubeconfig_filename`, which references a created kubeconfig file that can be
+   used by setting the `KUBECONFIG` environment variable

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -56,7 +56,7 @@ module "aws_hcp_consul" {
   # This is required because the hcp_hvn.main.hvn_id does not block
   # on HVN creation, and thus we need to wait until the HVN is
   # successfully created.
-  depends_on         = [hcp_hvn.main]
+  depends_on = [hcp_hvn.main]
 }
 
 resource "hcp_consul_cluster" "main" {

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -1,0 +1,88 @@
+data "aws_availability_zones" "available" {}
+
+data "aws_partition" "current" {}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.78.0"
+
+  name                 = "${var.cluster_id}-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+}
+
+module "eks" {
+  source          = "terraform-aws-modules/eks/aws"
+  cluster_name    = "hcp-${var.cluster_id}"
+  cluster_version = "1.21"
+  subnets         = module.vpc.public_subnets
+  vpc_id          = module.vpc.vpc_id
+
+  node_groups = {
+    application = {
+      desired_capacity = 3
+      max_capacity     = 3
+      min_capacity     = 3
+    }
+  }
+}
+
+# The HVN created in HCP
+resource "hcp_hvn" "main" {
+  hvn_id         = var.hvn_id
+  cloud_provider = "aws"
+  region         = var.region
+  cidr_block     = var.hvn_cidr_block
+}
+
+module "aws_hcp_consul" {
+  depends_on         = [hcp_hvn.main]
+  source             = "../../../terraform-aws-hcp-consul"
+  hvn_id             = hcp_hvn.main.hvn_id
+  vpc_id             = module.vpc.vpc_id
+  route_table_ids    = module.vpc.public_route_table_ids
+  security_group_ids = [module.eks.cluster_primary_security_group_id]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = var.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = !var.disable_public_url
+  size            = var.size
+  tier            = var.tier
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.cluster_id
+}
+
+module "eks_consul_client" {
+  source = "../../modules/hcp-eks-client"
+
+  cluster_id       = hcp_consul_cluster.main.cluster_id
+  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  k8s_api_endpoint = module.eks.cluster_endpoint
+
+  boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  datacenter            = hcp_consul_cluster.main.datacenter
+  gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+
+  # The EKS node group will fail to create if the clients are
+  # created at the same time. This forces the client to wait until
+  # the node group is successfully created.
+  depends_on = [module.eks]
+}

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -1,7 +1,5 @@
 data "aws_availability_zones" "available" {}
 
-data "aws_partition" "current" {}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -49,12 +49,16 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  depends_on         = [hcp_hvn.main]
   source             = "../../../terraform-aws-hcp-consul"
   hvn_id             = hcp_hvn.main.hvn_id
   vpc_id             = module.vpc.vpc_id
   route_table_ids    = module.vpc.public_route_table_ids
   security_group_ids = [module.eks.cluster_primary_security_group_id]
+
+  # This is required because the hcp_hvn.main.hvn_id does not block
+  # on HVN creation, and thus we need to wait until the HVN is
+  # successfully created.
+  depends_on         = [hcp_hvn.main]
 }
 
 resource "hcp_consul_cluster" "main" {

--- a/examples/hcp-eks-demo/output.tf
+++ b/examples/hcp-eks-demo/output.tf
@@ -1,0 +1,16 @@
+output "client_vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.public_endpoint ? (
+    hcp_consul_cluster.main.consul_public_endpoint_url
+    ) : (
+    hcp_consul_cluster.main.consul_private_endpoint_url
+  )
+}

--- a/examples/hcp-eks-demo/output.tf
+++ b/examples/hcp-eks-demo/output.tf
@@ -14,3 +14,7 @@ output "consul_url" {
     hcp_consul_cluster.main.consul_private_endpoint_url
   )
 }
+
+output "kubeconfig_filename" {
+  value = abspath(module.eks.kubeconfig_filename)
+}

--- a/examples/hcp-eks-demo/providers.tf
+++ b/examples/hcp-eks-demo/providers.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = ">= 0.15.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.4.1"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}

--- a/examples/hcp-eks-demo/variables.tf
+++ b/examples/hcp-eks-demo/variables.tf
@@ -1,0 +1,53 @@
+/*
+ *
+ * Optional Variables
+ *
+ */
+
+variable "cluster_id" {
+  type        = string
+  description = "The name of your HCP Consul cluster"
+  default     = "cluster-eks-demo"
+}
+
+variable "region" {
+  type        = string
+  description = "The AWS region to create resources in"
+  default     = "us-west-2"
+}
+
+# variable "vpc_cidr_block" {
+#   type        = string
+#   description = "The CIDR block to create the VPC in"
+#   default     = "172.25.16.0/20"
+# }
+
+variable "hvn_id" {
+  type        = string
+  description = "The name of your HCP HVN"
+  default     = "hvn-terraform"
+}
+
+variable "hvn_cidr_block" {
+  type        = string
+  description = "The CIDR range to create the HCP HVN with"
+  default     = "172.25.32.0/20"
+}
+
+variable "disable_public_url" {
+  type        = bool
+  description = "A boolean that determines whether the Consul cluster has a public URL"
+  default     = false
+}
+
+variable "size" {
+  type        = string
+  description = "The HCP Consul size to use when creating a Consul cluster"
+  default     = null
+}
+
+variable "tier" {
+  type        = string
+  description = "The HCP Consul tier to use when creating a Consul cluster"
+  default     = "development"
+}

--- a/examples/hcp-eks-demo/variables.tf
+++ b/examples/hcp-eks-demo/variables.tf
@@ -16,12 +16,6 @@ variable "region" {
   default     = "us-west-2"
 }
 
-# variable "vpc_cidr_block" {
-#   type        = string
-#   description = "The CIDR block to create the VPC in"
-#   default     = "172.25.16.0/20"
-# }
-
 variable "hvn_id" {
   type        = string
   description = "The name of your HCP HVN"

--- a/modules/hcp-eks-client/main.tf
+++ b/modules/hcp-eks-client/main.tf
@@ -1,0 +1,33 @@
+resource "kubernetes_secret" "consul_secrets" {
+  metadata {
+    name = "${var.cluster_id}-hcp"
+  }
+
+  data = {
+    caCert              = var.consul_ca_file
+    gossipEncryptionKey = var.gossip_encryption_key
+    bootstrapToken      = var.boostrap_acl_token
+  }
+
+  type = "Opaque"
+}
+
+resource "helm_release" "consul" {
+  name       = "consul"
+  repository = "https://helm.releases.hashicorp.com"
+  version    = "0.33.0"
+  chart      = "consul"
+
+  values = [
+    templatefile("${path.module}/templates/consul.tpl", {
+      datacenter       = var.datacenter
+      consul_hosts     = jsonencode(var.consul_hosts)
+      cluster_id       = var.cluster_id
+      k8s_api_endpoint = var.k8s_api_endpoint
+    })
+  ]
+
+  # Helm installation relies on the Kuberenetes secret being
+  # available.
+  depends_on = [kubernetes_secret.consul_secrets]
+}

--- a/modules/hcp-eks-client/main.tf
+++ b/modules/hcp-eks-client/main.tf
@@ -15,7 +15,7 @@ resource "kubernetes_secret" "consul_secrets" {
 resource "helm_release" "consul" {
   name       = "consul"
   repository = "https://helm.releases.hashicorp.com"
-  version    = "0.33.0"
+  version    = var.chart_version
   chart      = "consul"
 
   values = [

--- a/modules/hcp-eks-client/templates/consul.tpl
+++ b/modules/hcp-eks-client/templates/consul.tpl
@@ -1,0 +1,42 @@
+global:
+  enabled: false
+  name: consul
+  datacenter: ${datacenter}
+  image: "hashicorp/consul-enterprise:1.10.2-ent"
+  acls:
+    manageSystemACLs: true
+    bootstrapToken:
+      secretName: ${cluster_id}-hcp
+      secretKey: bootstrapToken
+  tls:
+    enabled: true
+    enableAutoEncrypt: true
+    caCert:
+      secretName: ${cluster_id}-hcp
+      secretKey: caCert
+  gossipEncryption:
+    secretName: ${cluster_id}-hcp
+    secretKey: gossipEncryptionKey
+
+externalServers:
+  enabled: true
+  hosts: ${consul_hosts}
+  httpsPort: 443
+  useSystemRoots: true
+  k8sAuthMethodHost: ${k8s_api_endpoint}
+
+server:
+  enabled: false
+
+client:
+  enabled: true
+  join: ${consul_hosts}
+
+connectInject:
+  enabled: true
+
+ui:
+  enabled: true
+
+controller:
+  enabled: true

--- a/modules/hcp-eks-client/variables.tf
+++ b/modules/hcp-eks-client/variables.tf
@@ -1,0 +1,39 @@
+/*
+ *
+ * Required Variables
+ *
+ */
+variable "boostrap_acl_token" {
+  type        = string
+  description = "The ACL bootstrap token used to create necessary ACL tokens for the Helm chart"
+}
+
+variable "gossip_encryption_key" {
+  type        = string
+  description = "The gossip encryption key of the Consul cluster"
+}
+
+variable "consul_ca_file" {
+  type        = string
+  description = "The Consul CA certificate bundle used to validate TLS connections"
+}
+
+variable "datacenter" {
+  type        = string
+  description = "The name of the Consul datacenter that client agents should register as"
+}
+
+variable "consul_hosts" {
+  type        = list(string)
+  description = "A list of DNS addresses that clients should use to join the Consul cluster"
+}
+
+variable "k8s_api_endpoint" {
+  type        = string
+  description = "The Kubernetes API endpoint for the Kubernetes cluster"
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "The ID of the Consul cluster that is managing the clients"
+}

--- a/modules/hcp-eks-client/variables.tf
+++ b/modules/hcp-eks-client/variables.tf
@@ -3,6 +3,7 @@
  * Required Variables
  *
  */
+
 variable "boostrap_acl_token" {
   type        = string
   description = "The ACL bootstrap token used to create necessary ACL tokens for the Helm chart"
@@ -36,4 +37,16 @@ variable "k8s_api_endpoint" {
 variable "cluster_id" {
   type        = string
   description = "The ID of the Consul cluster that is managing the clients"
+}
+
+/*
+ *
+ * Optional Variables
+ *
+ */
+
+variable "chart_version" {
+  type        = string
+  description = "The Consul Helm chart version to use"
+  default     = "0.33.0"
 }


### PR DESCRIPTION
This PR creates the `hcp-eks-demo` example and `hcp-eks-client` submodule.

Currently, this will work and standup an EKS cluster attached to a HCP Consul cluster.

TODO:
- [x] : Configure the correct outputs
- [x] : Ensure that k8s applications can be registered with the EKS cluster and work