### PR TITLE
Create security group in root module and run terraform fmt in CI

### DIFF
--- a/.github/workflows/terraform-aws-hcp-consul.yml
+++ b/.github/workflows/terraform-aws-hcp-consul.yml
@@ -1,0 +1,9 @@
+name: 'AWS HCP Consul Terraform Module'
+on: [push, pull_request]
+jobs:
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1
+      - run: terraform fmt -check -recursive

--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -27,7 +27,6 @@ module "aws_hcp_consul" {
   hvn_id                    = hcp_hvn.main.hvn_id
   vpc_id                    = module.vpc.vpc_id
   route_table_ids           = module.vpc.public_route_table_ids
-  security_group_ids        = [module.vpc.default_security_group_id]
 
   # This is required because the hcp_hvn.main.hvn_id does not block
   # on HVN creation, and thus we need to wait until the HVN is
@@ -51,8 +50,9 @@ module "aws_ec2_consul_client" {
   depends_on              = [module.aws_hcp_consul]
   source                  = "../../modules/hcp-ec2-client"
   subnet_id               = module.vpc.public_subnets[0]
-  security_group_id       = module.vpc.default_security_group_id
+  security_group_id       = module.aws_hcp_consul.security_group_ids[0]
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
+  allowed_http_cidr_blocks = ["0.0.0.0/0"]
   client_config_file      = hcp_consul_cluster.main.consul_config_file
   client_ca_file          = hcp_consul_cluster.main.consul_ca_file
   root_token              = hcp_consul_cluster_root_token.token.secret_id

--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -11,6 +11,6 @@ output "consul_url" {
   )
 }
 
-output "service_instance_ids" {
+output "clients" {
   value = module.aws_ec2_consul_client
 }

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ locals {
     },
   ]
 
+  # If a list of security_group_ids was provided, construct a rule set.
   hcp_consul_security_groups = flatten([
     for _, sg in var.security_group_ids : [
       for _, rule in local.ingress_consul_rules : {
@@ -76,7 +77,8 @@ resource "aws_route" "peering" {
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.vpc_peering_connection_id
 }
 
-resource "aws_security_group_rule" "hcp_consul" {
+# If a list of security_group_ids was provided, set rules on those.
+resource "aws_security_group_rule" "hcp_consul_existing_grp" {
   count             = length(local.hcp_consul_security_groups)
   description       = local.hcp_consul_security_groups[count.index].description
   protocol          = local.hcp_consul_security_groups[count.index].protocol
@@ -84,5 +86,49 @@ resource "aws_security_group_rule" "hcp_consul" {
   cidr_blocks       = [data.hcp_hvn.selected.cidr_block]
   from_port         = local.hcp_consul_security_groups[count.index].port
   to_port           = local.hcp_consul_security_groups[count.index].port
+  type              = "ingress"
+}
+
+# If no security_group_ids were provided, create a new security_group.
+resource "aws_security_group" "hcp_consul" {
+  count = length(var.security_group_ids) == 0 ? 1 : 0
+  name_prefix = "hcp_consul"
+  description = "HCP Consul security group"
+  vpc_id      = data.aws_vpc.selected.id
+}
+
+# If no security_group_ids were provided, use the new security_group.
+resource "aws_security_group_rule" "hcp_consul_new_grp" {
+  count = length(var.security_group_ids) == 0 ? length(local.ingress_consul_rules) : 0
+  description       = local.ingress_consul_rules[count.index].description
+  protocol          = local.ingress_consul_rules[count.index].protocol
+  security_group_id = aws_security_group.hcp_consul[0].id
+  cidr_blocks       = [data.hcp_hvn.selected.cidr_block]
+  from_port         = local.ingress_consul_rules[count.index].port
+  to_port           = local.ingress_consul_rules[count.index].port
+  type              = "ingress"
+}
+
+# If no security_group_ids were provided, allow egress on the new security_group.
+resource "aws_security_group_rule" "allow_all_egress" {
+  count = length(var.security_group_ids) == 0 ? 1 : 0
+  description       = "Allow egress access to the Internet."
+  protocol          = "-1"
+  security_group_id = aws_security_group.hcp_consul[0].id
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  type              = "egress"
+}
+
+# If no security_group_ids were provided, allow self ingress on the new security_group.
+resource "aws_security_group_rule" "allow_self" {
+  count = length(var.security_group_ids) == 0 ? 1 : 0
+  description       = "Allow egress access to the Internet."
+  protocol          = "-1"
+  security_group_id = aws_security_group.hcp_consul[0].id
+  self              = true
+  from_port         = 0
+  to_port           = 0
   type              = "ingress"
 }

--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -25,6 +25,17 @@ resource "aws_security_group_rule" "allow_ssh_inbound" {
   security_group_id = var.security_group_id
 }
 
+resource "aws_security_group_rule" "allow_http_inbound" {
+  count       = length(var.allowed_http_cidr_blocks) >= 1 ? 1 : 0
+  type        = "ingress"
+  from_port   = 8080
+  to_port     = 8080
+  protocol    = "tcp"
+  cidr_blocks = var.allowed_http_cidr_blocks
+
+  security_group_id = var.security_group_id
+}
+
 resource "aws_instance" "consul_client_dashboard" {
   count                       = 1
   ami                         = data.aws_ami.ubuntu.id

--- a/modules/hcp-ec2-client/output.tf
+++ b/modules/hcp-ec2-client/output.tf
@@ -1,6 +1,15 @@
 output "dashboard_id" {
   value = aws_instance.consul_client_dashboard[0].id
 }
+
 output "counting_id" {
   value = aws_instance.consul_client_counting[0].id
+}
+
+output "dashboard_url" {
+  value = "http://${aws_instance.consul_client_dashboard[0].public_ip}:8080"
+}
+
+output "counting_url" {
+  value = "http://${aws_instance.consul_client_counting[0].public_ip}:8080"
 }

--- a/modules/hcp-ec2-client/templates/install.sh
+++ b/modules/hcp-ec2-client/templates/install.sh
@@ -18,7 +18,7 @@ setup_deps () {
   # Dependencies added
   sudo add-apt-repository universe -y
   sudo apt update -yq
-  sudo apt install apt-transport-https gnupg2 curl lsb-release
+  sudo apt install -yq apt-transport-https gnupg2 curl lsb-release
   curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | sudo gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/getenvoy.list
   sudo apt update -yq

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -9,6 +9,12 @@ variable "allowed_ssh_cidr_blocks" {
   default     = []
 }
 
+variable "allowed_http_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections over 8080"
+  type        = list(string)
+  default     = []
+}
+
 variable "client_config_file" {
   type        = string
   description = "The client config file provided by HCP"

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,8 @@
+output "security_group_ids" {
+  description = "List of security group IDs that allow Consul client communication"
+  value = length(var.security_group_ids) == 0 ? (
+    aws_security_group.hcp_consul.*.id
+    ) : (
+      var.security_group_ids
+  )
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,4 +22,5 @@ variable "route_table_ids" {
 variable "security_group_ids" {
   type        = list(string)
   description = "A list of security group IDs which should allow inbound Consul client traffic"
+  default     = []
 }


### PR DESCRIPTION
If a user does not provide any security_group_ids, then we create one
for them to use.

This security group sets the following rules:
- Consul client ingress rules (port 8301) for the HVN CIDR ranges
- Allows all ports between members of the same security_group
- Allows egress to the Internet

In addition, we fix an issue with the template.sh script that required
interactive input when downloading apt repositories.

We also provide optional variables to expose the EC2 public IPs on port
8080, so that a user can easily access the demo applications.

Also, configure Github actions to run `terraform fmt` on PR and push.