### PR TITLE
Use envoy proxy for hcp-ec2-client module

### DIFF
--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -59,7 +59,7 @@ resource "aws_instance" "consul_client_dashboard" {
     }),
     sidecar_service = templatefile("${path.module}/templates/service", {
       service_name = "sidecar",
-      service_cmd  = "/usr/bin/consul connect proxy -sidecar-for dashboard-service -token ${var.root_token}",
+      service_cmd  = "/usr/bin/consul connect envoy -sidecar-for dashboard-service -token ${var.root_token}",
     }),
   })
 
@@ -96,7 +96,7 @@ resource "aws_instance" "consul_client_counting" {
     }),
     sidecar_service = templatefile("${path.module}/templates/service", {
       service_name = "sidecar",
-      service_cmd  = "/usr/bin/consul connect proxy -sidecar-for counting-service -token ${var.root_token}",
+      service_cmd  = "/usr/bin/consul connect envoy -sidecar-for counting-service -token ${var.root_token}",
     }),
   })
 

--- a/modules/hcp-ec2-client/templates/install.sh
+++ b/modules/hcp-ec2-client/templates/install.sh
@@ -51,8 +51,10 @@ jq -n --arg token "${consul_acl_token}" '{"acl": {"tokens": {"agent": "\($token)
 
 # Replace the relative path with the explicit path where consul will run
 echo "$(jq '.ca_file = "/etc/consul.d/ca.pem"' client_config.temp )" > client_config.json
+echo '{"ports": { "grpc": 8502 }}' > ports.json
 sudo mv client_config.json /etc/consul.d
 sudo mv client_acl.json /etc/consul.d
+sudo mv ports.json /etc/consul.d
 sudo mv ca.pem /etc/consul.d
 
 start_service "consul"


### PR DESCRIPTION
HCP Consul config does not set the gRPC port, thus we need to specify
that as an additional config file.