### PR TITLE
Use subnet_ids variable to create HVN routes

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -22,14 +22,10 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source          = "../../../terraform-aws-hcp-consul"
-  hvn_id          = hcp_hvn.main.hvn_id
+  hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.public_subnets
   route_table_ids = module.vpc.public_route_table_ids
-
-  # This is required because the hcp_hvn.main.hvn_id does not block
-  # on HVN creation, and thus we need to wait until the HVN is
-  # successfully created.
-  depends_on = [hcp_hvn.main]
 }
 
 resource "hcp_consul_cluster" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,14 +4,23 @@
  *
  */
 
-variable "hvn_id" {
-  type        = string
-  description = "The ID of your HCP HVN"
+variable "hvn" {
+  type = object({
+    hvn_id     = string
+    self_link  = string
+    cidr_block = string
+  })
+  description = "The HCP HVN to connect to the VPC"
 }
 
 variable "vpc_id" {
   type        = string
   description = "The ID of your AWS VPC"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "A list of subnet IDs which should route to/from the the HVN's CIDR"
 }
 
 variable "route_table_ids" {


### PR DESCRIPTION
This scopes down the routing necessary to only the subnets needed,
rather than using the entire VPC CIDR range.

This commit also changes the root module to take in an entire hvn object
as a parameter, instead of the hvn_id. This lets us remove a depends_on
parameter in the examples, thus making it easier to use.