### PR TITLE
examples: use remote registry source in examples

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -21,7 +21,8 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  source          = "../../../terraform-aws-hcp-consul"
+  source = "hashicorp/hcp-consul/aws"
+
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
   subnet_ids      = module.vpc.public_subnets
@@ -41,8 +42,8 @@ resource "hcp_consul_cluster_root_token" "token" {
 }
 
 module "aws_ec2_consul_client" {
-  depends_on               = [module.aws_hcp_consul]
-  source                   = "../../modules/hcp-ec2-client"
+  source = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
+
   subnet_id                = module.vpc.public_subnets[0]
   security_group_id        = module.aws_hcp_consul.security_group_id
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -50,4 +51,6 @@ module "aws_ec2_consul_client" {
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
+
+  depends_on = [module.aws_hcp_consul]
 }

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -46,7 +46,8 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  source             = "../../../terraform-aws-hcp-consul"
+  source = "hashicorp/hcp-consul/aws"
+
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
   subnet_ids         = module.vpc.public_subnets
@@ -67,7 +68,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 }
 
 module "eks_consul_client" {
-  source = "../../modules/hcp-eks-client"
+  source = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -85,6 +86,6 @@ module "eks_consul_client" {
 }
 
 module "demo_app" {
-  source     = "../../modules/k8s-demo-app"
+  source     = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
   depends_on = [module.eks_consul_client]
 }

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -13,15 +13,23 @@ import (
 
 func TestTerraform_EC2DemoExample(t *testing.T) {
 	r := require.New(t)
+
+	tmpDir, err := CreateTestTerraform(t, "../examples/hcp-ec2-demo")
+	r.NoError(err)
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/hcp-ec2-demo",
+		TerraformDir: tmpDir,
 		Vars: map[string]interface{}{
-			"cluster_id": "test-ec2-example",
+			"cluster_id": "test-ec2",
+			"hvn_id":     "test-ec2",
 		},
 		NoColor: true,
 	})
 
 	t.Cleanup(func() {
+		// Set Vars to nil because the destroy can fail validation based on
+		// variables provided, such as length of an identifier, and the variables
+		// are not necessary for a destroy operation.
+		terraformOptions.Vars = nil
 		terraform.Destroy(t, terraformOptions)
 	})
 
@@ -80,15 +88,24 @@ func TestTerraform_EC2DemoExample(t *testing.T) {
 
 func TestTerraform_EKSDemoExample(t *testing.T) {
 	r := require.New(t)
+
+	tmpDir, err := CreateTestTerraform(t, "../examples/hcp-eks-demo")
+	r.NoError(err)
+
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/hcp-eks-demo",
+		TerraformDir: tmpDir,
 		Vars: map[string]interface{}{
-			"cluster_id": "test-eks-example",
+			"cluster_id": "test-eks",
+			"hvn_id":     "test-eks",
 		},
 		NoColor: true,
 	})
 
 	t.Cleanup(func() {
+		// Set Vars to nil because the destroy can fail validation based on
+		// variables provided, such as length of an identifier, and the variables
+		// are not necessary for a destroy operation.
+		terraformOptions.Vars = nil
 		terraform.Destroy(t, terraformOptions)
 	})
 

--- a/test/local_sources.go
+++ b/test/local_sources.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The value here is the directory based on relative path from the various
+// examples
+var localSourceMap = map[string]string{
+	"hashicorp/hcp-consul/aws":                         "../..",
+	"hashicorp/hcp-consul/aws//modules/hcp-ec2-client": "../../modules/hcp-ec2-client",
+	"hashicorp/hcp-consul/aws//modules/hcp-eks-client": "../../modules/hcp-eks-client",
+	"hashicorp/hcp-consul/aws//modules/k8s-demo-app":   "../../modules/k8s-demo-app",
+}
+
+func CreateTestTerraform(t *testing.T, exampleDir string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", filepath.Base(exampleDir))
+	if err != nil {
+		return "", err
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	err = fs.WalkDir(os.DirFS(exampleDir), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Only walk the root directory, do not recurse.
+		if path != "." && d.IsDir() {
+			return fs.SkipDir
+		}
+
+		// If terraform file, copy to tmpDir
+		if strings.HasSuffix(d.Name(), ".tf") {
+			data, err := os.ReadFile(filepath.Join(exampleDir, d.Name()))
+			if err != nil {
+				return err
+			}
+
+			// Change the remote sources to use local sources
+			for r, l := range localSourceMap {
+				localPath, err := filepath.Abs(filepath.Join(exampleDir, l))
+				if err != nil {
+					return err
+				}
+				data = regexp.MustCompile(r).ReplaceAllLiteral(data, []byte(localPath))
+			}
+
+			err = os.WriteFile(filepath.Join(tmpDir, d.Name()), data, 0644)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return tmpDir, nil
+}


### PR DESCRIPTION
Add functionality in the tests that maps remote module sources to local
module sources, copies the examples to a temp dir, modifies the source
to the local path, and then runs the test. This ensures we will test the
new versions of modules before they are released on the TF Registry.