### PR TITLE
Add HCP UI templates

### DIFF
--- a/.github/workflows/terraform-aws-hcp-consul.yml
+++ b/.github/workflows/terraform-aws-hcp-consul.yml
@@ -13,3 +13,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
       - run: terraform fmt -check -recursive
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      - run: go test ./hcp
+        working-directory: ./test

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -56,7 +56,7 @@ module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
   version = "0.3.0"
 
-  subnet_id                = module.vpc.public_subnets[0]
+  subnet_id                = local.subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+  }
+}
+
+locals {
+  vpc_region     = "{{ .VPCRegion }}"
+  hvn_region     = "{{ .HVNRegion }}"
+  cluster_id     = "{{ .ClusterID }}"
+  vpc_id         = "{{ .VPCID }}"
+  route_table_id = "{{ .RouteTableID }}"
+  subnet1        = "{{ .Subnet1 }}"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn             = hcp_hvn.main
+  vpc_id          = local.vpc_id
+  subnet_ids      = [local.subnet1]
+  route_table_ids = [local.route_table_id]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "aws_ec2_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
+  version = "0.3.0"
+
+  subnet_id                = module.vpc.public_subnets[0]
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
+  allowed_http_cidr_blocks = ["0.0.0.0/0"]
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "nomad_ec2_id" {
+  value = module.aws_ec2_consul_client.host_id
+}
+
+output "hashicups_url" {
+  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+}

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -1,0 +1,94 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+  }
+}
+
+locals {
+  vpc_region = "{{ .VPCRegion }}"
+  hvn_region = "{{ .HVNRegion }}"
+  cluster_id = "{{ .ClusterID }}"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.10.0"
+
+  name                 = "${local.cluster_id}-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = []
+  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  enable_dns_hostnames = true
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn             = hcp_hvn.main
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.public_subnets
+  route_table_ids = module.vpc.public_route_table_ids
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "aws_ec2_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
+  version = "0.3.0"
+
+  subnet_id                = module.vpc.public_subnets[0]
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
+  allowed_http_cidr_blocks = ["0.0.0.0/0"]
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "nomad_ec2_id" {
+  value = module.aws_ec2_consul_client.host_id
+}
+
+output "hashicups_url" {
+  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+}

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -1,0 +1,154 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.4"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.11"
+    }
+  }
+}
+
+locals {
+  vpc_region     = "{{ .VPCRegion }}"
+  hvn_region     = "{{ .HVNRegion }}"
+  cluster_id     = "{{ .ClusterID }}"
+  vpc_id         = "{{ .VPCID }}"
+  route_table_id = "{{ .RouteTableID }}"
+  subnet1        = "{{ .Subnet1 }}"
+  subnet2        = "{{ .Subnet2 }}"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.22.0"
+
+  cluster_name    = "${local.cluster_id}-eks"
+  cluster_version = "1.21"
+  subnets         = [local.subnet1, local.subnet2]
+  vpc_id          = local.vpc_id
+
+  node_groups = {
+    application = {
+      instance_types   = ["t3a.medium"]
+      desired_capacity = 3
+      max_capacity     = 3
+      min_capacity     = 3
+    }
+  }
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn                = hcp_hvn.main
+  vpc_id             = local.vpc_id
+  subnet_ids         = [local.subnet1, local.subnet2]
+  route_table_ids    = [local.route_table_id]
+  security_group_ids = [module.eks.cluster_primary_security_group_id]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "eks_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
+  version = "0.3.0"
+
+  cluster_id       = hcp_consul_cluster.main.cluster_id
+  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  k8s_api_endpoint = module.eks.cluster_endpoint
+
+  boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  datacenter            = hcp_consul_cluster.main.datacenter
+  gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+
+  depends_on = [module.eks]
+}
+
+module "demo_app" {
+  source     = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
+  version    = "0.3.0"
+  depends_on = [module.eks_consul_client]
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "kubeconfig_filename" {
+  value = abspath(module.eks.kubeconfig_filename)
+}
+
+output "hashicups_url" {
+  value = module.demo_app.hashicups_url
+}

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -77,6 +77,7 @@ module "eks" {
 
   node_groups = {
     application = {
+      name_prefix      = "hashicups"
       instance_types   = ["t3a.medium"]
       desired_capacity = 3
       max_capacity     = 3

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -89,6 +89,7 @@ module "eks" {
 
   node_groups = {
     application = {
+      name_prefix      = "hashicups"
       instance_types   = ["t3a.medium"]
       desired_capacity = 3
       max_capacity     = 3

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -1,0 +1,166 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.4"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.11"
+    }
+  }
+}
+
+locals {
+  vpc_region = "{{ .VPCRegion }}"
+  hvn_region = "{{ .HVNRegion }}"
+  cluster_id = "{{ .ClusterID }}"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.10.0"
+
+  name                 = "${local.cluster_id}-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.22.0"
+
+  cluster_name    = "${local.cluster_id}-eks"
+  cluster_version = "1.21"
+  subnets         = module.vpc.private_subnets
+  vpc_id          = module.vpc.vpc_id
+
+  node_groups = {
+    application = {
+      instance_types   = ["t3a.medium"]
+      desired_capacity = 3
+      max_capacity     = 3
+      min_capacity     = 3
+    }
+  }
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn                = hcp_hvn.main
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+  route_table_ids    = module.vpc.private_route_table_ids
+  security_group_ids = [module.eks.cluster_primary_security_group_id]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "eks_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
+  version = "0.3.0"
+
+  cluster_id       = hcp_consul_cluster.main.cluster_id
+  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  k8s_api_endpoint = module.eks.cluster_endpoint
+
+  boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  datacenter            = hcp_consul_cluster.main.datacenter
+  gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+
+  depends_on = [module.eks]
+}
+
+module "demo_app" {
+  source     = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
+  version    = "0.3.0"
+  depends_on = [module.eks_consul_client]
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "kubeconfig_filename" {
+  value = abspath(module.eks.kubeconfig_filename)
+}
+
+output "hashicups_url" {
+  value = module.demo_app.hashicups_url
+}

--- a/test/README.md
+++ b/test/README.md
@@ -5,10 +5,27 @@ test out this modules provided examples.
 
 #### Instructions
 
-Running the tests requires AWS and HCP credentials, make sure to set up those as
+There are two different sets of tests in this directory:
+1. `examples`: Integration-level tests that ensure the examples are working as expected
+2. `hcp`: Unit tests ensuring that the HCP UI templates do not change
+   unintentionally
+
+Running the `hcp` suite of tests requires no outside setup. Run this within the
+test/ directory:
+```
+go test ./hcp
+```
+
+To update the HCP unit tests, run this command and the golden files will be
+updated with any changes made to the templates:
+```
+go test ./hcp -update
+```
+
+Running the example tests requires AWS and HCP credentials, make sure to set up those as
 environment variables.
 
 To run the tests, run this within the test/ directory:
 ```
-go test ./... -v -timeout 30m
+go test ./examples -v -timeout 1h
 ```

--- a/test/examples/examples_test.go
+++ b/test/examples/examples_test.go
@@ -1,4 +1,4 @@
-package test
+package examples
 
 import (
 	"net/http"
@@ -14,7 +14,7 @@ import (
 func TestTerraform_EC2DemoExample(t *testing.T) {
 	r := require.New(t)
 
-	tmpDir, err := CreateTestTerraform(t, "../examples/hcp-ec2-demo")
+	tmpDir, err := CreateTestTerraform(t, "../../examples/hcp-ec2-demo")
 	r.NoError(err)
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
@@ -97,7 +97,7 @@ func TestTerraform_EC2DemoExample(t *testing.T) {
 func TestTerraform_EKSDemoExample(t *testing.T) {
 	r := require.New(t)
 
-	tmpDir, err := CreateTestTerraform(t, "../examples/hcp-eks-demo")
+	tmpDir, err := CreateTestTerraform(t, "../../examples/hcp-eks-demo")
 	r.NoError(err)
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{

--- a/test/examples/local_sources.go
+++ b/test/examples/local_sources.go
@@ -1,4 +1,4 @@
-package test
+package examples
 
 import (
 	"io/fs"

--- a/test/hcp/hcp_test.go
+++ b/test/hcp/hcp_test.go
@@ -1,0 +1,114 @@
+package hcp
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+)
+
+type HCPTemplate struct {
+	VPCRegion    string
+	HVNRegion    string
+	VPCID        string
+	ClusterID    string
+	RouteTableID string
+	Subnet1      string
+	Subnet2      string
+}
+
+const (
+	hcpRootDir = "../../hcp-ui-templates"
+)
+
+// update allows golden files to be updated based on the current output.
+var update = flag.Bool("update", false, "update golden files")
+
+func TestHCPTemplates(t *testing.T) {
+	cases := []struct {
+		name           string
+		templatePath   string
+		templateValues HCPTemplate
+	}{
+		{
+			name:         "ec2",
+			templatePath: filepath.Join(hcpRootDir, "ec2", "main.tf"),
+			templateValues: HCPTemplate{
+				VPCRegion: "us-west-2",
+				HVNRegion: "us-west-2",
+				ClusterID: "consul-quickstart-1634271483588",
+			},
+		},
+		{
+			name:         "ec2-existing-vpc",
+			templatePath: filepath.Join(hcpRootDir, "ec2-existing-vpc", "main.tf"),
+			templateValues: HCPTemplate{
+				VPCRegion:    "us-east-1",
+				HVNRegion:    "us-west-2",
+				ClusterID:    "consul-quickstart-2634271483588",
+				VPCID:        "vpc-071d21e09127bb012",
+				RouteTableID: "rtb-02b0b92efeae83c28",
+				Subnet1:      "subnet-04afc1709a875ad5d",
+			},
+		},
+		{
+			name:         "eks",
+			templatePath: filepath.Join(hcpRootDir, "eks", "main.tf"),
+			templateValues: HCPTemplate{
+				VPCRegion: "us-west-2",
+				HVNRegion: "us-west-2",
+				ClusterID: "consul-quickstart-3634271483588",
+			},
+		},
+		{
+			name:         "eks-existing-vpc",
+			templatePath: filepath.Join(hcpRootDir, "eks-existing-vpc", "main.tf"),
+			templateValues: HCPTemplate{
+				VPCRegion:    "eu-west-1",
+				HVNRegion:    "eu-west-2",
+				ClusterID:    "consul-quickstart-4634271483588",
+				VPCID:        "vpc-171d21e09127bb012",
+				RouteTableID: "rtb-12b0b92efeae83c28",
+				Subnet1:      "subnet-14afc1709a875ad5d",
+				Subnet2:      "subnet-1aa8d55f44387908d",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
+			temp, err := template.ParseFiles(c.templatePath)
+			r.NoError(err)
+
+			var buf bytes.Buffer
+			r.NoError(temp.Execute(&buf, c.templateValues))
+
+			r.Equal(golden(t, c.name, buf.String()), buf.String())
+		})
+	}
+}
+
+// golden returns the byte array of the requested golden file, in order to
+// compare against the test-generated value. If the -update flag was passed,
+// this also updates the golden file itself.
+func golden(t *testing.T, name string, got string) string {
+	t.Helper()
+
+	golden := filepath.Join("testdata", name+".golden")
+
+	// Update the golden file if the update flag was passed in.
+	if *update && len(got) != 0 {
+		require.NoError(t, os.WriteFile(golden, []byte(got), 0644))
+		return got
+	}
+
+	data, err := os.ReadFile(golden)
+	require.NoError(t, err)
+
+	return string(data)
+}

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -78,10 +78,6 @@ output "nomad_ec2_id" {
   value = module.aws_ec2_consul_client.host_id
 }
 
-output "nomad_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8081"
-}
-
 output "hashicups_url" {
   value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
 }

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -1,0 +1,87 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+  }
+}
+
+locals {
+  vpc_region     = "us-east-1"
+  hvn_region     = "us-west-2"
+  cluster_id     = "consul-quickstart-2634271483588"
+  vpc_id         = "vpc-071d21e09127bb012"
+  route_table_id = "rtb-02b0b92efeae83c28"
+  subnet1        = "subnet-04afc1709a875ad5d"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn             = hcp_hvn.main
+  vpc_id          = local.vpc_id
+  subnet_ids      = [local.subnet1]
+  route_table_ids = [local.route_table_id]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "aws_ec2_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
+  version = "0.3.0"
+
+  subnet_id                = module.vpc.public_subnets[0]
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
+  allowed_http_cidr_blocks = ["0.0.0.0/0"]
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "nomad_ec2_id" {
+  value = module.aws_ec2_consul_client.host_id
+}
+
+output "nomad_url" {
+  value = "http://${module.aws_ec2_consul_client.host_dns}:8081"
+}
+
+output "hashicups_url" {
+  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+}

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -56,7 +56,7 @@ module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
   version = "0.3.0"
 
-  subnet_id                = module.vpc.public_subnets[0]
+  subnet_id                = local.subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -89,10 +89,6 @@ output "nomad_ec2_id" {
   value = module.aws_ec2_consul_client.host_id
 }
 
-output "nomad_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8081"
-}
-
 output "hashicups_url" {
   value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
 }

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -1,0 +1,98 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+  }
+}
+
+locals {
+  vpc_region = "us-west-2"
+  hvn_region = "us-west-2"
+  cluster_id = "consul-quickstart-1634271483588"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.10.0"
+
+  name                 = "${local.cluster_id}-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = []
+  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  enable_dns_hostnames = true
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn             = hcp_hvn.main
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.public_subnets
+  route_table_ids = module.vpc.public_route_table_ids
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "aws_ec2_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
+  version = "0.3.0"
+
+  subnet_id                = module.vpc.public_subnets[0]
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
+  allowed_http_cidr_blocks = ["0.0.0.0/0"]
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "nomad_ec2_id" {
+  value = module.aws_ec2_consul_client.host_id
+}
+
+output "nomad_url" {
+  value = "http://${module.aws_ec2_consul_client.host_dns}:8081"
+}
+
+output "hashicups_url" {
+  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+}

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -77,6 +77,7 @@ module "eks" {
 
   node_groups = {
     application = {
+      name_prefix      = "hashicups"
       instance_types   = ["t3a.medium"]
       desired_capacity = 3
       max_capacity     = 3

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -1,0 +1,154 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.4"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.11"
+    }
+  }
+}
+
+locals {
+  vpc_region     = "eu-west-1"
+  hvn_region     = "eu-west-2"
+  cluster_id     = "consul-quickstart-4634271483588"
+  vpc_id         = "vpc-171d21e09127bb012"
+  route_table_id = "rtb-12b0b92efeae83c28"
+  subnet1        = "subnet-14afc1709a875ad5d"
+  subnet2        = "subnet-1aa8d55f44387908d"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.22.0"
+
+  cluster_name    = "${local.cluster_id}-eks"
+  cluster_version = "1.21"
+  subnets         = [local.subnet1, local.subnet2]
+  vpc_id          = local.vpc_id
+
+  node_groups = {
+    application = {
+      instance_types   = ["t3a.medium"]
+      desired_capacity = 3
+      max_capacity     = 3
+      min_capacity     = 3
+    }
+  }
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn                = hcp_hvn.main
+  vpc_id             = local.vpc_id
+  subnet_ids         = [local.subnet1, local.subnet2]
+  route_table_ids    = [local.route_table_id]
+  security_group_ids = [module.eks.cluster_primary_security_group_id]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "eks_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
+  version = "0.3.0"
+
+  cluster_id       = hcp_consul_cluster.main.cluster_id
+  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  k8s_api_endpoint = module.eks.cluster_endpoint
+
+  boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  datacenter            = hcp_consul_cluster.main.datacenter
+  gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+
+  depends_on = [module.eks]
+}
+
+module "demo_app" {
+  source     = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
+  version    = "0.3.0"
+  depends_on = [module.eks_consul_client]
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "kubeconfig_filename" {
+  value = abspath(module.eks.kubeconfig_filename)
+}
+
+output "hashicups_url" {
+  value = module.demo_app.hashicups_url
+}

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -89,6 +89,7 @@ module "eks" {
 
   node_groups = {
     application = {
+      name_prefix      = "hashicups"
       instance_types   = ["t3a.medium"]
       desired_capacity = 3
       max_capacity     = 3

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -1,0 +1,166 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.43"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = "~> 0.19"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.4"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.11"
+    }
+  }
+}
+
+locals {
+  vpc_region = "us-west-2"
+  hvn_region = "us-west-2"
+  cluster_id = "consul-quickstart-3634271483588"
+}
+
+provider "aws" {
+  region = local.vpc_region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.10.0"
+
+  name                 = "${local.cluster_id}-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.22.0"
+
+  cluster_name    = "${local.cluster_id}-eks"
+  cluster_version = "1.21"
+  subnets         = module.vpc.private_subnets
+  vpc_id          = module.vpc.vpc_id
+
+  node_groups = {
+    application = {
+      instance_types   = ["t3a.medium"]
+      desired_capacity = 3
+      max_capacity     = 3
+      min_capacity     = 3
+    }
+  }
+}
+
+resource "hcp_hvn" "main" {
+  hvn_id         = "${local.cluster_id}-hvn"
+  cloud_provider = "aws"
+  region         = local.hvn_region
+  cidr_block     = "172.25.32.0/20"
+}
+
+module "aws_hcp_consul" {
+  source  = "hashicorp/hcp-consul/aws"
+  version = "0.3.0"
+
+  hvn                = hcp_hvn.main
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+  route_table_ids    = module.vpc.private_route_table_ids
+  security_group_ids = [module.eks.cluster_primary_security_group_id]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = local.cluster_id
+  hvn_id          = hcp_hvn.main.hvn_id
+  public_endpoint = true
+  tier            = "development"
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "eks_consul_client" {
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
+  version = "0.3.0"
+
+  cluster_id       = hcp_consul_cluster.main.cluster_id
+  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  k8s_api_endpoint = module.eks.cluster_endpoint
+
+  boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  datacenter            = hcp_consul_cluster.main.datacenter
+  gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+
+  depends_on = [module.eks]
+}
+
+module "demo_app" {
+  source     = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
+  version    = "0.3.0"
+  depends_on = [module.eks_consul_client]
+}
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+output "kubeconfig_filename" {
+  value = abspath(module.eks.kubeconfig_filename)
+}
+
+output "hashicups_url" {
+  value = module.demo_app.hashicups_url
+}


### PR DESCRIPTION
This PR adds the `hcp-ui-templates` directory, which the HCP Portal will use to construct the quick-start Terraform files.

This PR also adds a new set of tests, in `test/hcp`, which assert on golden files for the 4 different quick-start options. This allows us to ensure we do not accidentally change the quickstart files.