### PR TITLE
Only use VPC ID in peering ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ data "aws_subnet" "selected" {
 }
 
 resource "hcp_aws_network_peering" "default" {
-  peering_id      = "${var.hvn.hvn_id}-${data.aws_vpc.selected.id}"
+  peering_id      = "${data.aws_vpc.selected.id}-peering"
   hvn_id          = var.hvn.hvn_id
   peer_vpc_id     = data.aws_vpc.selected.id
   peer_account_id = data.aws_vpc.selected.owner_id


### PR DESCRIPTION
The peering ID has a 36 character limit, and a VPC id is ~22 characters,
which leaves a small amount of characters for the HVN id. The peering is
already associated with a HVN, and so there is no reason to have it in
the name.

Running tests:
```
$ go test ./... -timeout 1h
ok  	github.com/hashicorp/terraform-aws-hcp-consul/test	2403.551s
```