### PR TITLE
Provision EKS cluster in private subnets

### DIFF
--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -15,8 +15,10 @@ module "vpc" {
   name                 = "${var.cluster_id}-vpc"
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
-  private_subnets      = []
-  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
   enable_dns_hostnames = true
 }
 
@@ -24,7 +26,7 @@ module "eks" {
   source          = "terraform-aws-modules/eks/aws"
   cluster_name    = "hcp-${var.cluster_id}"
   cluster_version = "1.21"
-  subnets         = module.vpc.public_subnets
+  subnets         = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
 
   node_groups = {
@@ -50,8 +52,8 @@ module "aws_hcp_consul" {
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.public_subnets
-  route_table_ids    = module.vpc.public_route_table_ids
+  subnet_ids         = module.vpc.private_subnets
+  route_table_ids    = module.vpc.private_route_table_ids
   security_group_ids = [module.eks.cluster_primary_security_group_id]
 }
 


### PR DESCRIPTION
This makes the examples a bit more secure.

Ran the EKS examples test:
```
TestTerraform_EKSDemoExample 2021-10-26T13:53:31-05:00 logger.go:66: Destroy complete! Resources: 66 destroyed.
--- PASS: TestTerraform_EKSDemoExample (1637.84s)
PASS
ok  	github.com/hashicorp/terraform-aws-hcp-consul/test	1638.069s
```