### PR TITLE
Use id instead of cluster_id for requesting root token

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -38,7 +38,7 @@ resource "hcp_consul_cluster" "main" {
 }
 
 resource "hcp_consul_cluster_root_token" "token" {
-  cluster_id = hcp_consul_cluster.main.cluster_id
+  cluster_id = hcp_consul_cluster.main.id
 }
 
 module "aws_ec2_consul_client" {

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -64,7 +64,7 @@ resource "hcp_consul_cluster" "main" {
 }
 
 resource "hcp_consul_cluster_root_token" "token" {
-  cluster_id = hcp_consul_cluster.main.cluster_id
+  cluster_id = hcp_consul_cluster.main.id
 }
 
 module "eks_consul_client" {


### PR DESCRIPTION
This fixes an issue where the HCP Consul cluster would be recreated, but
the root token would not be.

This fix was added in `0.18.0` of the HCP provider, which we already require `>=`.
https://github.com/hashicorp/terraform-provider-hcp/pull/205