### PR TITLE
HCS-2570: Add terraform module to node meta

### DIFF
--- a/modules/hcp-eks-client/templates/consul.tpl
+++ b/modules/hcp-eks-client/templates/consul.tpl
@@ -31,6 +31,8 @@ server:
 client:
   enabled: true
   join: ${consul_hosts}
+  nodeMeta:
+    terraform-module: "hcp-eks-client"
 
 connectInject:
   enabled: true


### PR DESCRIPTION
Add a key-value pair to the Consul node metadata indicating which Terraform module was used to spin up the EKS Consul client.

Tested by:
- Running the hcp-eks-demo with this change, then opening the Consul web UI and verifying the client agents have the new metadata field (See screenshot below)

![20211110_100935](https://user-images.githubusercontent.com/11671852/141160820-323c00d1-8337-4fdd-883b-fafcfe813ede.png)
