### PR TITLE
wait for nomad.

### DIFF
--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -67,6 +67,9 @@ start_service "nomad"
 
 consul intention create -token "${consul_acl_token}" -allow '*' '*' || true
 
+# nomad service is type simple and might not be up and running just yet.
+sleep 10
+
 nomad run hashicups.nomad
 
 echo "done"


### PR DESCRIPTION
Ran into a bug where nomad wasn't started when we try to start hashicups. This should fix it.