### PR TITLE
add hvn_region to keep separate from eks region

### DIFF
--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -45,7 +45,7 @@ module "eks" {
 resource "hcp_hvn" "main" {
   hvn_id         = var.hvn_id
   cloud_provider = "aws"
-  region         = var.region
+  region         = var.hvn_region
   cidr_block     = var.hvn_cidr_block
 }
 

--- a/examples/hcp-eks-demo/output.tf
+++ b/examples/hcp-eks-demo/output.tf
@@ -14,7 +14,3 @@ output "consul_url" {
 output "kubeconfig_filename" {
   value = abspath(module.eks.kubeconfig_filename)
 }
-
-output "hashicups_url" {
-  value = module.demo_app.hashicups_url
-}

--- a/examples/hcp-eks-demo/variables.tf
+++ b/examples/hcp-eks-demo/variables.tf
@@ -7,13 +7,19 @@
 variable "cluster_id" {
   type        = string
   description = "The name of your HCP Consul cluster"
-  default     = "cluster-eks-demo"
+  default     = "dyu-eks-demo"
+}
+
+variable "hvn_region" {
+  type        = string
+  description = "The AWS region to create resources in"
+  default     = "us-west-2"
 }
 
 variable "region" {
   type        = string
   description = "The AWS region to create resources in"
-  default     = "us-west-2"
+  default     = "us-east-2"
 }
 
 variable "hvn_id" {


### PR DESCRIPTION
When deploying an EKS cluster in a different region than the HVN region, a separate variable should be used to deploy the infra in different regions. 

- added hvn_region variable
- temporarily removing the hashicups url variable, since Error: Unsupported attribute is shown at the moment