### PR TITLE
wait for consul to be up and running

### DIFF
--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -65,11 +65,11 @@ setup_consul
 start_service "consul"
 start_service "nomad"
 
-consul intention create -token "${consul_acl_token}" -allow '*' '*' || true
 
-# nomad service is type simple and might not be up and running just yet.
+# nomad and consul service is type simple and might not be up and running just yet.
 sleep 10
 
+consul intention create -token "${consul_acl_token}" -allow '*' '*' || true
 nomad run hashicups.nomad
 
 echo "done"


### PR DESCRIPTION
The intention might not be created if consul agent didn't have enough time to start properly.