### PR TITLE
Pin correct consul client version

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -51,6 +51,7 @@ module "aws_ec2_consul_client" {
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
+  consul_version           = hcp_consul_cluster.main.consul_version
 
   depends_on = [module.aws_hcp_consul]
 }

--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -16,5 +16,5 @@ output "nomad_url" {
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+  value = "http://${module.aws_ec2_consul_client.host_dns}"
 }

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -60,7 +60,8 @@ resource "hcp_consul_cluster_root_token" "token" {
 }
 
 module "aws_ecs_cluster" {
-  source = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
+  version = "~> 0.4.1"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
@@ -75,6 +76,7 @@ module "aws_ecs_cluster" {
   region                   = var.region
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
+  consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
 
   depends_on = [module.aws_hcp_consul]

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -72,11 +72,13 @@ resource "hcp_consul_cluster_root_token" "token" {
 }
 
 module "eks_consul_client" {
-  source = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
+  source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
+  version = "~> 0.4.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
   k8s_api_endpoint = module.eks.cluster_endpoint
+  consul_version   = hcp_consul_cluster.main.consul_version
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -80,5 +80,5 @@ output "nomad_ec2_id" {
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+  value = "http://${module.aws_ec2_consul_client.host_dns}"
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -54,7 +54,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   subnet_id                = local.public_subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -63,6 +63,7 @@ module "aws_ec2_consul_client" {
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
+  consul_version           = hcp_consul_cluster.main.consul_version
 }
 
 output "consul_root_token" {

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -91,5 +91,5 @@ output "nomad_url" {
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+  value = "http://${module.aws_ec2_consul_client.host_dns}"
 }

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -65,7 +65,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   subnet_id                = module.vpc.public_subnets[0]
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -74,6 +74,7 @@ module "aws_ec2_consul_client" {
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
+  consul_version           = hcp_consul_cluster.main.consul_version
 }
 
 output "consul_root_token" {

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -84,7 +84,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.4.0"
+  version = "~> 0.4.1"
 
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
@@ -100,6 +100,7 @@ module "aws_ecs_cluster" {
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   datacenter               = hcp_consul_cluster.main.datacenter
+  consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
 
   depends_on = [module.aws_hcp_consul]
 }

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -92,7 +92,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.4.0"
+  version = "~> 0.4.1"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
@@ -108,6 +108,7 @@ module "aws_ecs_cluster" {
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   datacenter               = hcp_consul_cluster.main.datacenter
+  consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
 
   depends_on = [module.aws_hcp_consul]
 }

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -117,11 +117,12 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
   k8s_api_endpoint = module.eks.cluster_endpoint
+  consul_version   = hcp_consul_cluster.main.consul_version
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -129,11 +129,12 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
   k8s_api_endpoint = module.eks.cluster_endpoint
+  consul_version   = hcp_consul_cluster.main.consul_version
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)

--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -58,7 +58,8 @@ resource "aws_instance" "nomad_host" {
     setup = base64gzip(templatefile("${path.module}/templates/setup.sh", {
       consul_config    = var.client_config_file,
       consul_ca        = var.client_ca_file,
-      consul_acl_token = var.root_token
+      consul_acl_token = var.root_token,
+      consul_version   = var.consul_version,
       consul_service = base64encode(templatefile("${path.module}/templates/service", {
         service_name = "consul",
         service_cmd  = "/usr/bin/consul agent -data-dir /var/consul -config-dir=/etc/consul.d/",

--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -39,8 +39,8 @@ resource "aws_security_group_rule" "allow_nomad_inbound" {
 resource "aws_security_group_rule" "allow_http_inbound" {
   count       = length(var.allowed_http_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"
-  from_port   = 8080
-  to_port     = 8080
+  from_port   = 80
+  to_port     = 80
   protocol    = "tcp"
   cidr_blocks = var.allowed_http_cidr_blocks
 

--- a/modules/hcp-ec2-client/templates/hashicups.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups.nomad
@@ -18,7 +18,7 @@ job "hashicups" {
           proxy {
             upstreams {
               destination_name = "product-public-api"
-              local_bind_port  = 18080
+              local_bind_port  = 8080
             }            
           }
         }
@@ -29,7 +29,7 @@ job "hashicups" {
       driver = "docker"
 
       config {
-        image = "hashicorpdemoapp/frontend:v0.0.5"
+        image = "hashicorpdemoapp/frontend:v0.0.7"
         ports = ["http"]
       }
     }

--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -14,7 +14,9 @@ setup_deps () {
   curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list
   apt update -qy
-  apt install -qy apt-transport-https gnupg2 curl lsb-release nomad consul-enterprise getenvoy-envoy unzip jq apache2-utils nginx
+	version="${consul_version}"
+	consul_package="consul-enterprise="$${version:1}"+ent"
+	apt install -qy apt-transport-https gnupg2 curl lsb-release nomad $${consul_package} getenvoy-envoy unzip jq apache2-utils nginx
 
 	curl -fsSL https://get.docker.com -o get-docker.sh
 	sh ./get-docker.sh

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -30,6 +30,11 @@ variable "root_token" {
   description = "The Consul Secret ID of the Consul root token"
 }
 
+variable "consul_version" {
+  type        = string
+  description = "The Consul version of the HCP servers"
+}
+
 variable "security_group_id" {
   type = string
 }

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -74,6 +74,7 @@ module "frontend" {
 
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
+  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
 
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
@@ -173,6 +174,7 @@ module "public_api" {
 
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
+  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
 
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
@@ -243,6 +245,7 @@ module "payment_api" {
 
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
+  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
 
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
@@ -330,6 +333,7 @@ module "product_api" {
 
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
+  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
 
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
@@ -414,6 +418,7 @@ module "product_db" {
 
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
+  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
 
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn

--- a/modules/hcp-ecs-client/variables.tf
+++ b/modules/hcp-ecs-client/variables.tf
@@ -60,6 +60,11 @@ variable "datacenter" {
   description = "The consul datacenter"
 }
 
+variable "consul_version" {
+  type        = string
+  description = "The Consul version of the HCP servers"
+}
+
 variable "region" {
   type        = string
   description = "The AWS region"

--- a/modules/hcp-eks-client/main.tf
+++ b/modules/hcp-eks-client/main.tf
@@ -24,6 +24,7 @@ resource "helm_release" "consul" {
       consul_hosts     = jsonencode(var.consul_hosts)
       cluster_id       = var.cluster_id
       k8s_api_endpoint = var.k8s_api_endpoint
+      consul_version   = substr(var.consul_version, 1, -1)
     })
   ]
 

--- a/modules/hcp-eks-client/templates/consul.tpl
+++ b/modules/hcp-eks-client/templates/consul.tpl
@@ -2,7 +2,7 @@ global:
   enabled: false
   name: consul
   datacenter: ${datacenter}
-  image: "hashicorp/consul-enterprise:1.10.3-ent"
+  image: "hashicorp/consul-enterprise:${consul_version}-ent"
   acls:
     manageSystemACLs: true
     bootstrapToken:

--- a/modules/hcp-eks-client/variables.tf
+++ b/modules/hcp-eks-client/variables.tf
@@ -39,6 +39,11 @@ variable "cluster_id" {
   description = "The ID of the Consul cluster that is managing the clients"
 }
 
+variable "consul_version" {
+  type        = string
+  description = "The Consul version of the HCP servers"
+}
+
 /*
  *
  * Optional Variables

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -80,5 +80,5 @@ output "nomad_ec2_id" {
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+  value = "http://${module.aws_ec2_consul_client.host_dns}"
 }

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -54,7 +54,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   subnet_id                = local.public_subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -63,6 +63,7 @@ module "aws_ec2_consul_client" {
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
+  consul_version           = hcp_consul_cluster.main.consul_version
 }
 
 output "consul_root_token" {

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -91,5 +91,5 @@ output "nomad_url" {
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8080"
+  value = "http://${module.aws_ec2_consul_client.host_dns}"
 }

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -65,7 +65,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   subnet_id                = module.vpc.public_subnets[0]
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -74,6 +74,7 @@ module "aws_ec2_consul_client" {
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
+  consul_version           = hcp_consul_cluster.main.consul_version
 }
 
 output "consul_root_token" {

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -84,7 +84,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.4.0"
+  version = "~> 0.4.1"
 
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
@@ -100,6 +100,7 @@ module "aws_ecs_cluster" {
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   datacenter               = hcp_consul_cluster.main.datacenter
+  consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
 
   depends_on = [module.aws_hcp_consul]
 }

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -92,7 +92,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.4.0"
+  version = "~> 0.4.1"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
@@ -108,6 +108,7 @@ module "aws_ecs_cluster" {
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   datacenter               = hcp_consul_cluster.main.datacenter
+  consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
 
   depends_on = [module.aws_hcp_consul]
 }

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -117,11 +117,12 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
   k8s_api_endpoint = module.eks.cluster_endpoint
+  consul_version   = hcp_consul_cluster.main.consul_version
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -129,11 +129,12 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "0.3.0"
+  version = "~> 0.4.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
   k8s_api_endpoint = module.eks.cluster_endpoint
+  consul_version   = hcp_consul_cluster.main.consul_version
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)


### PR DESCRIPTION
This PR pins the consul client version to the one the HCP Consul server is running. So that the clients can always connect properly and are not too far behind the server version or ahead of it. Both scenarios could cause problems.

This problem was discovered because the ec2 example stopped working when Consul 1.11 was released, but not yet recommended on HCP. Consul client v1.11 cannot connect to Consul server 1.10.

After merging this PR I am going to release `v0.4.1`.