### PR TITLE
Update hashicups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,11 @@ generate_templates:
 dummy_data: generate_templates
 	scripts/dummy_data.sh
 
+hashicups:
+	scripts/hashicups.sh
+
+dev:
+	scripts/dev.sh
+
 clean:
 	rm -rf examples/existing-vpc/output.json

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -22,7 +22,8 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  source = "hashicorp/hcp-consul/aws"
+  source  = "hashicorp/hcp-consul/aws"
+  version = "~> 0.4.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id

--- a/examples/hcp-ecs-demo/variables.tf
+++ b/examples/hcp-ecs-demo/variables.tf
@@ -16,6 +16,12 @@ variable "hvn_region" {
   default     = "us-west-2"
 }
 
+variable "vpc_region" {
+  type        = string
+  description = "The AWS region to create resources in"
+  default     = "us-west-2"
+}
+
 variable "hvn_id" {
   type        = string
   description = "The name of your HCP HVN"

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -46,7 +46,8 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  source = "hashicorp/hcp-consul/aws"
+  source  = "hashicorp/hcp-consul/aws"
+  version = "~> 0.4.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -56,7 +56,8 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  source = "hashicorp/hcp-consul/aws"
+  source  = "hashicorp/hcp-consul/aws"
+  version = "~> 0.4.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id

--- a/modules/hcp-ec2-client/templates/hashicups.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups.nomad
@@ -92,7 +92,7 @@ job "hashicups" {
       driver = "docker"
 
       config {
-        image = "hashicorpdemoapp/payments:v0.0.3"
+        image = "hashicorpdemoapp/payments:v0.0.16"
       }
     }
   }
@@ -134,7 +134,7 @@ job "hashicups" {
       driver = "docker"
 
       config {
-        image   = "hashicorpdemoapp/product-api:v0.0.18"
+        image   = "hashicorpdemoapp/product-api:v0.0.19"
       }
 
       env {
@@ -163,7 +163,7 @@ job "hashicups" {
       driver = "docker"
 
       config {
-        image = "hashicorpdemoapp/product-api-db:v0.0.17"
+        image = "hashicorpdemoapp/product-api-db:v0.0.19"
       }
 
       env {

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -28,7 +28,7 @@ module "frontend" {
   container_definitions = [
     {
       name      = "frontend"
-      image     = "hashicorpdemoapp/frontend:v0.0.6"
+      image     = "hashicorpdemoapp/frontend:v0.0.7"
       essential = true
       portMappings = [
         {
@@ -208,7 +208,7 @@ module "payment_api" {
   container_definitions = [
     {
       name      = "payment_api"
-      image     = "hashicorpdemoapp/payments:v0.0.3"
+      image     = "hashicorpdemoapp/payments:v0.0.16"
       essential = true
       portMappings = [
         {
@@ -279,7 +279,7 @@ module "product_api" {
   container_definitions = [
     {
       name      = "product_api"
-      image     = "hashicorpdemoapp/product-api:v0.0.18"
+      image     = "hashicorpdemoapp/product-api:v0.0.19"
       essential = true
       portMappings = [
         {
@@ -367,7 +367,7 @@ module "product_db" {
   container_definitions = [
     {
       name      = "product_db"
-      image     = "hashicorpdemoapp/product-api-db:v0.0.17"
+      image     = "hashicorpdemoapp/product-api-db:v0.0.19"
       essential = true
       portMappings = [
         {

--- a/modules/k8s-demo-app/services/frontend.yaml
+++ b/modules/k8s-demo-app/services/frontend.yaml
@@ -92,7 +92,7 @@ spec:
             path: default.conf
       containers:
         - name: frontend
-          image: hashicorpdemoapp/frontend:v0.0.5
+          image: hashicorpdemoapp/frontend:v0.0.7
           ports:
             - containerPort: 80
           volumeMounts:

--- a/modules/k8s-demo-app/services/payments.yaml
+++ b/modules/k8s-demo-app/services/payments.yaml
@@ -46,6 +46,6 @@ spec:
       serviceAccountName: payments
       containers:
         - name: payments
-          image: hashicorpdemoapp/payments:v0.0.12
+          image: hashicorpdemoapp/payments:v0.0.16
           ports:
             - containerPort: 8080

--- a/modules/k8s-demo-app/services/postgres.yaml
+++ b/modules/k8s-demo-app/services/postgres.yaml
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: postgres
       containers:
         - name: postgres
-          image: hashicorpdemoapp/product-api-db:v0.0.13
+          image: hashicorpdemoapp/product-api-db:v0.0.19
           ports:
             - containerPort: 5432
           env:

--- a/modules/k8s-demo-app/services/product-api.yaml
+++ b/modules/k8s-demo-app/services/product-api.yaml
@@ -67,7 +67,7 @@ spec:
             path: conf.json
       containers:
         - name: product-api
-          image: hashicorpdemoapp/product-api:v0.0.17
+          image: hashicorpdemoapp/product-api:v0.0.19
           ports:
             - containerPort: 9090
             - containerPort: 9103

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+dev () {
+  platform=$1
+  file="examples/hcp-$1-demo/main.tf"
+  perl -i -pe "BEGIN{undef \$/;} s/hashicorp\/hcp-consul\/aws\/\/modules\/hcp-$platform-client\"\r?\n  /..\/..\/modules\/hcp-$platform-client\"\n  # /smg" $file
+  perl -i -pe "BEGIN{undef \$/;} s/hashicorp\/hcp-consul\/aws\"\r?\n  /..\/..\/..\/terraform-aws-hcp-consul\"\n  # /smg" $file
+}
+
+for platform in ec2 ecs eks; do
+  dev $platform
+done

--- a/scripts/hashicups.sh
+++ b/scripts/hashicups.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# https://github.com/hashicorp-demoapp/hashicups-setups/blob/main/docker-compose-deployment/docker-compose.yaml
+FRONTEND_VERSION="v0.0.7"
+PUBLIC_API_VERSION="v0.0.5"
+PRODUCT_API_VERSION="v0.0.19"
+PRODUCT_API_DB_VERSION="v0.0.19"
+PAYMENT_API_VERSION="v0.0.16"
+
+version () {
+  file=$1
+
+  sed -i.bak "s/frontend:v[0-9.]*/frontend:${FRONTEND_VERSION}/" $file
+  sed -i.bak "s/public-api:v[0-9.]*/public-api:${PUBLIC_API_VERSION}/" $file
+  sed -i.bak "s/product-api:v[0-9.]*/product-api:${PRODUCT_API_VERSION}/" $file
+  sed -i.bak "s/product-api-db:v[0-9.]*/product-api-db:${PRODUCT_API_DB_VERSION}/" $file
+  sed -i.bak "s/payments:v[0-9.]*/payments:${PAYMENT_API_VERSION}/" $file
+
+  rm -rf $file.bak
+}
+
+# ec2
+version "modules/hcp-ec2-client/templates/hashicups.nomad"
+
+# eks
+for service in frontend payments public-api product-api postgres; do
+  version "modules/k8s-demo-app/services/$service.yaml"
+done
+
+# ecs
+version "modules/hcp-ecs-client/services.tf"

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -46,7 +46,8 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  source = "hashicorp/hcp-consul/aws"
+  source  = "hashicorp/hcp-consul/aws"
+  version = "~> 0.4.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -56,7 +56,8 @@ resource "hcp_hvn" "main" {
 }
 
 module "aws_hcp_consul" {
-  source = "hashicorp/hcp-consul/aws"
+  source  = "hashicorp/hcp-consul/aws"
+  version = "~> 0.4.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id


### PR DESCRIPTION
This PR adds a new make target: `make hashicups` which updates all hashicups images to version defined in `scripts/hashicups.sh`. That will make it easier to have a consistent setup across the examples.

I also implemented `make dev` to switch our examples into dev mode while developing. Mainly so that I don't have to do that manually to test our new hashicups versions.