### PR TITLE
HCS-2737 Replace wildcard with specific intentions and more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,9 @@
 
 generate_templates: hashicups_version module_version
 	scripts/generate_ui_templates.sh
-	scripts/terraform_fmt.sh
 
 dummy_data: generate_templates
 	scripts/dummy_data.sh
-	scripts/terraform_fmt.sh
 
 hashicups_version:
 	scripts/hashicups_version.sh

--- a/examples/hcp-ec2-demo/intentions.tf
+++ b/examples/hcp-ec2-demo/intentions.tf
@@ -1,0 +1,64 @@
+resource "consul_config_entry" "service_intentions_db" {
+  name = "product-db"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_product" {
+  name = "product-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_payment" {
+  name = "payment-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_public_api" {
+  name = "product-public-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "frontend"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+

--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -21,7 +21,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -42,7 +42,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   subnet_id                = module.vpc.public_subnets[0]
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -18,3 +18,7 @@ output "nomad_url" {
 output "hashicups_url" {
   value = "http://${module.aws_ec2_consul_client.host_dns}"
 }
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
+}

--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -12,11 +12,11 @@ output "consul_url" {
 }
 
 output "nomad_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8081"
+  value = "http://${module.aws_ec2_consul_client.public_ip}:8081"
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}"
+  value = "http://${module.aws_ec2_consul_client.public_ip}"
 }
 
 output "next_steps" {

--- a/examples/hcp-ec2-demo/providers.tf
+++ b/examples/hcp-ec2-demo/providers.tf
@@ -19,3 +19,9 @@ provider "aws" {
   region = var.vpc_region
 }
 
+provider "consul" {
+  address    = hcp_consul_cluster.main.consul_public_endpoint_url
+  datacenter = hcp_consul_cluster.main.datacenter
+  token      = hcp_consul_cluster_root_token.token.secret_id
+}
+

--- a/examples/hcp-ecs-demo/intentions.tf
+++ b/examples/hcp-ecs-demo/intentions.tf
@@ -1,0 +1,64 @@
+resource "consul_config_entry" "service_intentions_db" {
+  name = "product-db"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_product" {
+  name = "product-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_payment" {
+  name = "payment-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_public_api" {
+  name = "product-public-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "frontend"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -23,7 +23,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn    = hcp_hvn.main
   vpc_id = module.vpc.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets

--- a/examples/hcp-ecs-demo/output.tf
+++ b/examples/hcp-ecs-demo/output.tf
@@ -14,3 +14,7 @@ output "consul_url" {
 output "hashicups_url" {
   value = "http://${module.aws_ecs_cluster.hashicups_url}"
 }
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
+}

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -52,7 +52,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -74,7 +74,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -94,7 +94,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   depends_on = [module.eks_consul_client]
 }

--- a/examples/hcp-eks-demo/output.tf
+++ b/examples/hcp-eks-demo/output.tf
@@ -18,3 +18,7 @@ output "kubeconfig_filename" {
 output "hashicups_url" {
   value = module.demo_app.hashicups_url
 }
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
+}

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -26,6 +26,12 @@ provider "aws" {
   region = local.vpc_region
 }
 
+provider "consul" {
+  address    = hcp_consul_cluster.main.consul_public_endpoint_url
+  datacenter = hcp_consul_cluster.main.datacenter
+  token      = hcp_consul_cluster_root_token.token.secret_id
+}
+
 
 resource "hcp_hvn" "main" {
   hvn_id         = local.hvn_id
@@ -36,7 +42,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -57,7 +63,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   subnet_id                = local.public_subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -67,6 +73,74 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_version           = hcp_consul_cluster.main.consul_version
+
+  provisioner "local-exec" {
+    command = "echo Application startup takes ~2 minutes."
+  }
+}
+
+resource "consul_config_entry" "service_intentions_db" {
+  name = "product-db"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_product" {
+  name = "product-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_payment" {
+  name = "payment-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_public_api" {
+  name = "product-public-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "frontend"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
 }
 
 output "consul_root_token" {
@@ -83,9 +157,13 @@ output "consul_url" {
 }
 
 output "nomad_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8081"
+  value = "http://${module.aws_ec2_consul_client.public_ip}:8081"
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}"
+  value = "http://${module.aws_ec2_consul_client.public_ip}"
+}
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -73,10 +73,6 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_version           = hcp_consul_cluster.main.consul_version
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
 
 resource "consul_config_entry" "service_intentions_db" {

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -83,10 +83,6 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_version           = hcp_consul_cluster.main.consul_version
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
 
 resource "consul_config_entry" "service_intentions_db" {

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -105,11 +105,8 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
+
 resource "consul_config_entry" "service_intentions_db" {
   name = "product-db"
   kind = "service-intentions"

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -114,11 +114,8 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
+
 resource "consul_config_entry" "service_intentions_db" {
   name = "product-db"
   kind = "service-intentions"

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -98,7 +98,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -120,7 +120,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -140,7 +140,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   depends_on = [module.eks_consul_client]
 }
@@ -164,4 +164,8 @@ output "kubeconfig_filename" {
 
 output "hashicups_url" {
   value = module.demo_app.hashicups_url
+}
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -110,7 +110,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -132,7 +132,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   depends_on = [module.eks_consul_client]
 }
@@ -176,4 +176,8 @@ output "kubeconfig_filename" {
 
 output "hashicups_url" {
   value = module.demo_app.hashicups_url
+}
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
 }

--- a/modules/hcp-ec2-client/output.tf
+++ b/modules/hcp-ec2-client/output.tf
@@ -2,6 +2,6 @@ output "host_id" {
   value = aws_instance.nomad_host[0].id
 }
 
-output "host_dns" {
-  value = aws_instance.nomad_host[0].public_dns
+output "public_ip" {
+  value = aws_instance.nomad_host[0].public_ip
 }

--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -71,7 +71,6 @@ start_service "nomad"
 # nomad and consul service is type simple and might not be up and running just yet.
 sleep 10
 
-consul intention create -token "${consul_acl_token}" -allow '*' '*' || true
 nomad run hashicups.nomad
 
 echo "done"

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -1,6 +1,5 @@
 module "acl-controller" {
-  source           = "hashicorp/consul-ecs/aws//modules/acl-controller"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source = "hashicorp/consul-ecs/aws//modules/acl-controller"
 
   log_configuration = {
     logDriver = "awslogs"
@@ -55,8 +54,8 @@ resource "aws_iam_role" "frontend-execution-role" {
 }
 
 module "frontend" {
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version = "~> 0.3.0"
 
   family         = "frontend"
   task_role      = aws_iam_role.frontend-task-role
@@ -176,8 +175,8 @@ resource "aws_iam_role" "public_api-execution-role" {
 }
 
 module "public_api" {
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version = "~> 0.3.0"
 
   family         = "public_api"
   task_role      = aws_iam_role.public_api-task-role
@@ -306,8 +305,8 @@ resource "aws_iam_role" "payment_api-execution-role" {
 }
 
 module "payment_api" {
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version = "~> 0.3.0"
 
   family         = "payment_api"
   task_role      = aws_iam_role.payment_api-task-role
@@ -413,8 +412,8 @@ resource "aws_iam_role" "product_api-execution-role" {
 }
 
 module "product_api" {
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version = "~> 0.3.0"
 
   family         = "product_api"
   task_role      = aws_iam_role.product_api-task-role
@@ -537,8 +536,8 @@ resource "aws_iam_role" "product_db-execution-role" {
 }
 
 module "product_db" {
-  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
-  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version = "~> 0.3.0"
 
   family         = "product_db"
   task_role      = aws_iam_role.product_db-task-role

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -1,6 +1,6 @@
 module "acl-controller" {
-  source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
-  version = "~> 0.2.0"
+  source           = "hashicorp/consul-ecs/aws//modules/acl-controller"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
 
   log_configuration = {
     logDriver = "awslogs"
@@ -20,11 +20,47 @@ module "acl-controller" {
   name_prefix = local.secret_prefix
 }
 
-module "frontend" {
-  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.2.0"
+resource "aws_iam_role" "frontend-task-role" {
+  name = "frontend_${local.scope}_task_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
 
-  family = "frontend_${local.scope}"
+resource "aws_iam_role" "frontend-execution-role" {
+  name = "frontend_${local.scope}_execution_role"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+module "frontend" {
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+
+  family         = "frontend"
+  task_role      = aws_iam_role.frontend-task-role
+  execution_role = aws_iam_role.frontend-execution-role
   container_definitions = [
     {
       name      = "frontend"
@@ -55,8 +91,8 @@ module "frontend" {
 
   upstreams = [
     {
-      destination_name = "public_api_${local.scope}"
-      local_bind_port  = 8080
+      destinationName = "public_api"
+      localBindPort   = 8080
     },
   ]
 
@@ -105,12 +141,47 @@ resource "aws_ecs_service" "frontend" {
   enable_execute_command = true
 }
 
+resource "aws_iam_role" "public_api-task-role" {
+  name = "public_api_${local.scope}_task_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "public_api-execution-role" {
+  name = "public_api_${local.scope}_execution_role"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
 module "public_api" {
-  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.2.0"
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
 
-
-  family = "public_api_${local.scope}"
+  family         = "public_api"
+  task_role      = aws_iam_role.public_api-task-role
+  execution_role = aws_iam_role.public_api-execution-role
   container_definitions = [
     {
       name      = "public_api"
@@ -151,12 +222,12 @@ module "public_api" {
 
   upstreams = [
     {
-      destination_name = "product_api_${local.scope}"
-      local_bind_port  = 5000
+      destinationName = "product_api"
+      localBindPort   = 5000
     },
     {
-      destination_name = "payment_api_${local.scope}"
-      local_bind_port  = 5001
+      destinationName = "payment_api"
+      localBindPort   = 5001
     }
   ]
 
@@ -200,11 +271,47 @@ resource "aws_ecs_service" "public_api" {
   enable_execute_command = true
 }
 
-module "payment_api" {
-  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.2.0"
+resource "aws_iam_role" "payment_api-task-role" {
+  name = "payment_api_${local.scope}_task_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
 
-  family = "payment_api_${local.scope}"
+resource "aws_iam_role" "payment_api-execution-role" {
+  name = "payment_api_${local.scope}_execution_role"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+module "payment_api" {
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+
+  family         = "payment_api"
+  task_role      = aws_iam_role.payment_api-task-role
+  execution_role = aws_iam_role.payment_api-execution-role
   container_definitions = [
     {
       name      = "payment_api"
@@ -271,11 +378,47 @@ resource "aws_ecs_service" "payment_api" {
   enable_execute_command = true
 }
 
-module "product_api" {
-  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.2.0"
+resource "aws_iam_role" "product_api-task-role" {
+  name = "product_api_${local.scope}_task_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
 
-  family = "product_api_${local.scope}"
+resource "aws_iam_role" "product_api-execution-role" {
+  name = "product_api_${local.scope}_execution_role"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+module "product_api" {
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+
+  family         = "product_api"
+  task_role      = aws_iam_role.product_api-task-role
+  execution_role = aws_iam_role.product_api-execution-role
   container_definitions = [
     {
       name      = "product_api"
@@ -315,8 +458,8 @@ module "product_api" {
 
   upstreams = [
     {
-      destination_name = "product_db_${local.scope}"
-      local_bind_port  = 5000
+      destinationName = "product_db"
+      localBindPort   = 5000
     }
   ]
 
@@ -359,11 +502,47 @@ resource "aws_ecs_service" "product_api" {
   enable_execute_command = true
 }
 
-module "product_db" {
-  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.2.0"
+resource "aws_iam_role" "product_db-task-role" {
+  name = "product_db_${local.scope}_task_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
 
-  family = "product_db_${local.scope}"
+resource "aws_iam_role" "product_db-execution-role" {
+  name = "product_db_${local.scope}_execution_role"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+module "product_db" {
+  source           = "github.com/hashicorp/terraform-aws-consul-ecs//modules/mesh-task"
+  consul_ecs_image = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+
+  family         = "product_db"
+  task_role      = aws_iam_role.product_db-task-role
+  execution_role = aws_iam_role.product_db-execution-role
   container_definitions = [
     {
       name      = "product_db"

--- a/scripts/dummy_data.sh
+++ b/scripts/dummy_data.sh
@@ -31,3 +31,4 @@ for template in ec2 ec2-existing-vpc eks eks-existing-vpc ecs ecs-existing-vpc; 
   defaults $template
 done
 
+source ./scripts/terraform_fmt.sh

--- a/scripts/generate_ui_templates.sh
+++ b/scripts/generate_ui_templates.sh
@@ -60,3 +60,9 @@ generate () {
 for platform in ec2 eks ecs; do
   generate $platform
 done
+
+source ./scripts/terraform_fmt.sh
+
+cd test/hcp
+go test -update .
+cd -

--- a/scripts/generate_ui_templates.sh
+++ b/scripts/generate_ui_templates.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 generate_base_terraform () {
-  cat examples/hcp-$1-demo/providers.tf examples/hcp-$1-demo/main.tf examples/hcp-$1-demo/output.tf \
+  cat examples/hcp-$1-demo/{providers,main,intentions,output}.tf \
     | sed -e '/provider_meta/,+2d' \
     | sed -e 's/var/local/g' \
     | sed -e 's/local\.tier/"development"/g' \
@@ -49,10 +49,12 @@ generate_existing_vpc_locals () {
 
 generate () {
   file=hcp-ui-templates/$1/main.tf
+  mkdir -p $(dirname $file)
   generate_locals > $file
   generate_base_terraform $1 >> $file
 
   file=hcp-ui-templates/$1-existing-vpc/main.tf
+  mkdir -p $(dirname $file)
   generate_existing_vpc_locals $1 > $file
   generate_existing_vpc_terraform $1 >> $file
 }

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.5\.0"
-new=0.5.1
+old="0\.5\.1"
+new=0.6.0
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -26,6 +26,12 @@ provider "aws" {
   region = local.vpc_region
 }
 
+provider "consul" {
+  address    = hcp_consul_cluster.main.consul_public_endpoint_url
+  datacenter = hcp_consul_cluster.main.datacenter
+  token      = hcp_consul_cluster_root_token.token.secret_id
+}
+
 
 resource "hcp_hvn" "main" {
   hvn_id         = local.hvn_id
@@ -36,7 +42,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -57,7 +63,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   subnet_id                = local.public_subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -67,6 +73,74 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_version           = hcp_consul_cluster.main.consul_version
+
+  provisioner "local-exec" {
+    command = "echo Application startup takes ~2 minutes."
+  }
+}
+
+resource "consul_config_entry" "service_intentions_db" {
+  name = "product-db"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_product" {
+  name = "product-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_payment" {
+  name = "payment-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "product-public-api"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
+}
+
+resource "consul_config_entry" "service_intentions_public_api" {
+  name = "product-public-api"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "frontend"
+        Precedence = 9
+        Type       = "consul"
+      },
+    ]
+  })
 }
 
 output "consul_root_token" {
@@ -83,9 +157,13 @@ output "consul_url" {
 }
 
 output "nomad_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}:8081"
+  value = "http://${module.aws_ec2_consul_client.public_ip}:8081"
 }
 
 output "hashicups_url" {
-  value = "http://${module.aws_ec2_consul_client.host_dns}"
+  value = "http://${module.aws_ec2_consul_client.public_ip}"
+}
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
 }

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -73,10 +73,6 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_version           = hcp_consul_cluster.main.consul_version
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
 
 resource "consul_config_entry" "service_intentions_db" {

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -83,10 +83,6 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_version           = hcp_consul_cluster.main.consul_version
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
 
 resource "consul_config_entry" "service_intentions_db" {

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -105,11 +105,8 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
+
 resource "consul_config_entry" "service_intentions_db" {
   name = "product-db"
   kind = "service-intentions"

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -114,11 +114,8 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-
-  provisioner "local-exec" {
-    command = "echo Application startup takes ~2 minutes."
-  }
 }
+
 resource "consul_config_entry" "service_intentions_db" {
   name = "product-db"
   kind = "service-intentions"

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -98,7 +98,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -120,7 +120,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -140,7 +140,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   depends_on = [module.eks_consul_client]
 }
@@ -164,4 +164,8 @@ output "kubeconfig_filename" {
 
 output "hashicups_url" {
   value = module.demo_app.hashicups_url
+}
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -110,7 +110,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -132,7 +132,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.5.1"
+  version = "~> 0.6.0"
 
   depends_on = [module.eks_consul_client]
 }
@@ -176,4 +176,8 @@ output "kubeconfig_filename" {
 
 output "hashicups_url" {
   value = module.demo_app.hashicups_url
+}
+
+output "next_steps" {
+  value = "Hashicups Application will be ready in ~2 minutes"
 }


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/HCS-2737)

✅ Wait until the consul-ecs terraform is released so that we can use a version in source.

Changes:

* ecs: back to normal service names
* ecs and ec2: specific intentions instead of wildcard allow
* add output asking the user to wait for demo application to launch
* prepare for module version `0.6.0`

<img width="805" alt="Screenshot 2022-01-20 at 23 25 02" src="https://user-images.githubusercontent.com/38218/150432138-40ce8ca9-75d0-4478-82b4-3d34d059c5ff.png">

Best viewed by commit.
