### PR TITLE
Add more guidance

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -21,7 +21,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -42,7 +42,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   subnet_id                = module.vpc.public_subnets[0]
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -20,5 +20,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -23,7 +23,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn    = hcp_hvn.main
   vpc_id = module.vpc.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets

--- a/examples/hcp-ecs-demo/output.tf
+++ b/examples/hcp-ecs-demo/output.tf
@@ -16,5 +16,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -52,7 +52,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -74,7 +74,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -94,7 +94,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   depends_on = [module.eks_consul_client]
 }

--- a/examples/hcp-eks-demo/output.tf
+++ b/examples/hcp-eks-demo/output.tf
@@ -20,5 +20,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -42,7 +42,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -63,7 +63,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   subnet_id                = local.public_subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -161,5 +161,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -52,7 +52,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -73,7 +73,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   subnet_id                = module.vpc.public_subnets[0]
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -171,5 +171,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn    = hcp_hvn.main
   vpc_id = local.vpc_id
@@ -88,7 +88,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
@@ -189,5 +189,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -54,7 +54,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn    = hcp_hvn.main
   vpc_id = module.vpc.vpc_id
@@ -97,7 +97,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
@@ -198,5 +198,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -98,7 +98,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -120,7 +120,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -140,7 +140,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   depends_on = [module.eks_consul_client]
 }
@@ -167,5 +167,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -110,7 +110,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -132,7 +132,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   depends_on = [module.eks_consul_client]
 }
@@ -179,5 +179,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.5\.1"
-new=0.6.0
+old="0\.6\.0"
+new=0.6.1
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -42,7 +42,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -63,7 +63,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   subnet_id                = local.public_subnet1
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -161,5 +161,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -52,7 +52,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -73,7 +73,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   subnet_id                = module.vpc.public_subnets[0]
   security_group_id        = module.aws_hcp_consul.security_group_id
@@ -171,5 +171,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn    = hcp_hvn.main
   vpc_id = local.vpc_id
@@ -88,7 +88,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
@@ -189,5 +189,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -54,7 +54,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn    = hcp_hvn.main
   vpc_id = module.vpc.vpc_id
@@ -97,7 +97,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
@@ -198,5 +198,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -98,7 +98,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -120,7 +120,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -140,7 +140,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   depends_on = [module.eks_consul_client]
 }
@@ -167,5 +167,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -110,7 +110,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -132,7 +132,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 
 module "demo_app" {
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.6.0"
+  version = "~> 0.6.1"
 
   depends_on = [module.eks_consul_client]
 }
@@ -179,5 +179,5 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes"
+  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
 }


### PR DESCRIPTION
This PR adds a little bit more guidance in the terraform output. Next steps will now say: 

```
Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token.
```

It also updates the module version to `0.6.1` which is technically not required, but this is the way the changes get pulled into the HCP UI. 

Best viewed by commit, the first commit shows the changes, the second commit regenerates everything else.