### PR TITLE
Hashicups Update for hcp-ec2-client module

### DIFF
--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -70,6 +70,7 @@ resource "aws_instance" "nomad_host" {
       })),
       hashicups  = base64encode(file("${path.module}/templates/hashicups.nomad")),
       nginx_conf = base64encode(file("${path.module}/templates/nginx.conf")),
+      vpc_cidr   = var.vpc_cidr
     })),
   })
 

--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -36,6 +36,17 @@ resource "aws_security_group_rule" "allow_nomad_inbound" {
   security_group_id = var.security_group_id
 }
 
+resource "aws_security_group_rule" "allow_public_api_inbound" {
+  count       = length(var.allowed_http_cidr_blocks) >= 1 ? 1 : 0
+  type        = "ingress"
+  from_port   = 8080
+  to_port     = 8080
+  protocol    = "tcp"
+  cidr_blocks = var.allowed_http_cidr_blocks
+
+  security_group_id = var.security_group_id
+}
+
 resource "aws_security_group_rule" "allow_http_inbound" {
   count       = length(var.allowed_http_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"

--- a/modules/hcp-ec2-client/templates/hashicups.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups.nomad
@@ -57,8 +57,7 @@ job "hashicups" {
     service {
       name = "product-public-api"
       port = NOMAD_PORT_http
-      tags = ["urlprefix-/"]
-
+      
       connect {
         sidecar_service {
           proxy {

--- a/modules/hcp-ec2-client/templates/hashicups.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups.nomad
@@ -1,3 +1,10 @@
+variable "public_api_ip" {
+  type        = string
+  description = "Public Host IP Address"
+  default     = "localhost"
+}
+
+
 job "hashicups" {
   datacenters = ["dc1"]
 
@@ -11,7 +18,7 @@ job "hashicups" {
 
     service {
       name = "frontend"
-      port = "80"
+      port = NOMAD_PORT_http
 
       connect {
         sidecar_service {
@@ -19,7 +26,7 @@ job "hashicups" {
             upstreams {
               destination_name = "product-public-api"
               local_bind_port  = 8080
-            }            
+            }
           }
         }
       }
@@ -27,9 +34,13 @@ job "hashicups" {
 
     task "frontend" {
       driver = "docker"
+      env {
+        PORT                       = NOMAD_PORT_http
+        NEXT_PUBLIC_PUBLIC_API_URL = "http://${var.public_api_ip}:8080"
+      }
 
       config {
-        image = "hashicorpdemoapp/frontend:v0.0.7"
+        image = "hashicorpdemoapp/frontend:v1.0.1"
         ports = ["http"]
       }
     }
@@ -38,11 +49,15 @@ job "hashicups" {
   group "product-public-api" {
     network {
       mode = "bridge"
+      port "http" {
+        static = 8080
+      }
     }
 
     service {
       name = "product-public-api"
-      port = "8080"
+      port = NOMAD_PORT_http
+      tags = ["urlprefix-/"]
 
       connect {
         sidecar_service {
@@ -50,7 +65,7 @@ job "hashicups" {
             upstreams {
               destination_name = "product-api"
               local_bind_port  = 5000
-            }            
+            }
             upstreams {
               destination_name = "payment-api"
               local_bind_port  = 5001
@@ -64,7 +79,7 @@ job "hashicups" {
       driver = "docker"
 
       config {
-        image   = "hashicorpdemoapp/public-api:v0.0.5"
+        image = "hashicorpdemoapp/public-api:v0.0.6"
       }
 
       env {
@@ -82,6 +97,7 @@ job "hashicups" {
     service {
       name = "payment-api"
       port = "8080"
+
 
       connect {
         sidecar_service {}
@@ -134,13 +150,13 @@ job "hashicups" {
       driver = "docker"
 
       config {
-        image   = "hashicorpdemoapp/product-api:v0.0.19"
+        image = "hashicorpdemoapp/product-api:v0.0.20"
       }
 
       env {
-        CONFIG_FILE = "/config/config.json"
-				DB_CONNECTION = "host=localhost port=5000 user=postgres password=password dbname=products sslmode=disable"
-				BIND_ADDRESS = "0.0.0.0:9090"
+        CONFIG_FILE   = "/config/config.json"
+        DB_CONNECTION = "host=localhost port=5000 user=postgres password=password dbname=products sslmode=disable"
+        BIND_ADDRESS  = "0.0.0.0:9090"
       }
     }
   }
@@ -163,7 +179,7 @@ job "hashicups" {
       driver = "docker"
 
       config {
-        image = "hashicorpdemoapp/product-api-db:v0.0.19"
+        image = "hashicorpdemoapp/product-api-db:v0.0.20"
       }
 
       env {

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -38,3 +38,9 @@ variable "consul_version" {
 variable "security_group_id" {
   type = string
 }
+
+variable "vpc_cidr" {
+  type        = string
+  description = "VPC CIDR"
+  default     = "10.0.0.0/8"
+}


### PR DESCRIPTION
[Hashicups UI](https://github.com/hashicorp-demoapp) was updated recently with a new [frontend](https://github.com/hashicorp-demoapp/frontend) container.

The new hashicups frontend container makes a client side call now to public_api thus requiring to open up the public_api service. This required the following:

- Updating setup.sh so it could retrieve the public IP address of the AWS EC2 instance running nomad
- hashicups nomad job now allows the ability to specify where the public_api is hosted as a nomad variable
- Setting Environment Variable NEXT_PUBLIC_PUBLIC_API_URL in the frontend task

In addition to using the hcp-ec2-client sub module, it assumes consul bind_addr will always be "10.0.0.0/8" VPC CIDR range. I've added a TF variable so we can specify a different cidr range for the consul client  configuration. The default CIDR range is still "10.0.0.0/8".