### PR TITLE
Specify AZ type to omit wavelength zones

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -1,4 +1,9 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "zone-type"
+    values = ["availability-zone"]
+  }
+}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -1,4 +1,9 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "zone-type"
+    values = ["availability-zone"]
+  }
+}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -1,4 +1,9 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "zone-type"
+    values = ["availability-zone"]
+  }
+}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"


### PR DESCRIPTION
While deploying EKS resources as shown by the Terraform in HCP Cloud, I was running into the failures shown by the attached screenshots.

<img width="1192" alt="Screen Shot 2022-02-23 at 11 46 40 AM (1)" src="https://user-images.githubusercontent.com/74205376/156018840-71213c49-63f3-4c75-9cb2-8a01808026e4.png">
<img width="885" alt="Screen Shot 2022-02-23 at 11 48 19 AM" src="https://user-images.githubusercontent.com/74205376/156018848-49ac5f13-5819-40c7-a7ea-9083d0fb19d1.png">

After some research and testing, this behavior is apparently caused by lack of feature parity between different types of Availability Zones (standard AZs vs wavelength zones). I filed a documentation update request to AWS to specify this expected behavior in their docs here: 
https://docs.aws.amazon.com/wavelength/latest/developerguide/wavelength-quotas.html#vpc-considerations

If the mentioned zone-type ype is set to availability-zone, resources will no longer potentially be created in Wavelength Zones (which causes this problem, and ultimately a deployment failure).

How to test it:
- Create two subnets (one in a standard AZ, one in a Wavelength AZ)
- Try to enable auto-assignment of IPs in each subnet (using the CLI or GUI)
- 
I got a failure every time when I tried it in Wavelength AZs.. and it worked everytime for standard AZs.

This small code change should solve it.