### PR TITLE
Fix EC2 module installation of Consul version

### DIFF
--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -15,7 +15,7 @@ setup_deps () {
   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list
   apt update -qy
 	version="${consul_version}"
-	consul_package="consul-enterprise="$${version:1}"+ent"
+	consul_package="consul-enterprise="$${version:1}"*"
 	apt install -qy apt-transport-https gnupg2 curl lsb-release nomad $${consul_package} getenvoy-envoy unzip jq apache2-utils nginx
 
 	curl -fsSL https://get.docker.com -o get-docker.sh


### PR DESCRIPTION
The apt repository of consul-enterprise has versions that do not exactly
match Consul versions itself. Notably, they can have a "-{digit}"
suffix, such as "1.11.5-1+ent". This commit ignores everything after the
version string, thus implicitly pulling in the latest of the "-{digit}"
versions.