### PR TITLE
Adding in subnet id so we can differentiate attached nodes 

### DIFF
--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -56,6 +56,7 @@ resource "aws_instance" "nomad_host" {
   vpc_security_group_ids      = [var.security_group_id]
   user_data = templatefile("${path.module}/templates/user_data.sh", {
     setup = base64gzip(templatefile("${path.module}/templates/setup.sh", {
+      subnet_id        = var.subnet_id,
       consul_config    = var.client_config_file,
       consul_ca        = var.client_ca_file,
       consul_acl_token = var.root_token,

--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -42,7 +42,7 @@ setup_consul() {
 	jq '.ca_file = "/etc/consul.d/ca.pem"' client.temp.0 > client.temp.1
 	jq --arg token "${consul_acl_token}" '.acl += {"tokens":{"agent":"\($token)"}}' client.temp.1 > client.temp.2
 	jq '.ports = {"grpc":8502}' client.temp.2 > client.temp.3
-	jq --arg token "${subnet_id}" '.acl += {"node_meta":{"subnet_id":"\($subnet_id)"}}' client.temp.3 > client.temp.4
+	jq --arg subnet_id "${subnet_id}" '.acl += {"node_meta":{"subnet_id":"\($subnet_id)"}}' client.temp.3 > client.temp.4
 	jq '.bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"'${vpc_cidr}'\" | attr \"address\" }}"' client.temp.4 > /etc/consul.d/client.json
 }
 

--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -42,7 +42,7 @@ setup_consul() {
 	jq '.ca_file = "/etc/consul.d/ca.pem"' client.temp.0 > client.temp.1
 	jq --arg token "${consul_acl_token}" '.acl += {"tokens":{"agent":"\($token)"}}' client.temp.1 > client.temp.2
 	jq '.ports = {"grpc":8502}' client.temp.2 > client.temp.3
-	jq --arg subnet_id "${subnet_id}" '.acl += {"node_meta":{"subnet_id":"\($subnet_id)"}}' client.temp.3 > client.temp.4
+	jq --arg subnet_id "${subnet_id}" '.node_meta += {"subnet_id":"\($subnet_id)"}' client.temp.3 > client.temp.4
 	jq '.bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"'${vpc_cidr}'\" | attr \"address\" }}"' client.temp.4 > /etc/consul.d/client.json
 }
 

--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -42,7 +42,8 @@ setup_consul() {
 	jq '.ca_file = "/etc/consul.d/ca.pem"' client.temp.0 > client.temp.1
 	jq --arg token "${consul_acl_token}" '.acl += {"tokens":{"agent":"\($token)"}}' client.temp.1 > client.temp.2
 	jq '.ports = {"grpc":8502}' client.temp.2 > client.temp.3
-	jq '.bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"'${vpc_cidr}'\" | attr \"address\" }}"' client.temp.3 > /etc/consul.d/client.json
+	jq --arg token "${subnet_id}" '.acl += {"node_meta":{"subnet_id":"\($subnet_id)"}}' client.temp.3 > client.temp.4
+	jq '.bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"'${vpc_cidr}'\" | attr \"address\" }}"' client.temp.4 > /etc/consul.d/client.json
 }
 
 setup_nginx() {


### PR DESCRIPTION
If we run this example and destroy and run it again a call to nodes list doesn't allow us to differentiate the nodes. Adding subnet id as node meta allows us to identify the node. Using subnet_id also avoids having to add another input variable to this example.