### PR TITLE
Switch from subnet_id to a new node_id field for the node_meta

### DIFF
--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -56,7 +56,7 @@ resource "aws_instance" "nomad_host" {
   vpc_security_group_ids      = [var.security_group_id]
   user_data = templatefile("${path.module}/templates/user_data.sh", {
     setup = base64gzip(templatefile("${path.module}/templates/setup.sh", {
-      subnet_id        = var.subnet_id,
+      node_id        = var.node_id,
       consul_config    = var.client_config_file,
       consul_ca        = var.client_ca_file,
       consul_acl_token = var.root_token,

--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -56,7 +56,7 @@ resource "aws_instance" "nomad_host" {
   vpc_security_group_ids      = [var.security_group_id]
   user_data = templatefile("${path.module}/templates/user_data.sh", {
     setup = base64gzip(templatefile("${path.module}/templates/setup.sh", {
-      node_id        = var.node_id,
+      node_id          = var.node_id,
       consul_config    = var.client_config_file,
       consul_ca        = var.client_ca_file,
       consul_acl_token = var.root_token,

--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -42,7 +42,7 @@ setup_consul() {
 	jq '.ca_file = "/etc/consul.d/ca.pem"' client.temp.0 > client.temp.1
 	jq --arg token "${consul_acl_token}" '.acl += {"tokens":{"agent":"\($token)"}}' client.temp.1 > client.temp.2
 	jq '.ports = {"grpc":8502}' client.temp.2 > client.temp.3
-	jq --arg subnet_id "${subnet_id}" '.node_meta += {"subnet_id":"\($subnet_id)"}' client.temp.3 > client.temp.4
+	jq --arg node_id "${node_id}" '.node_meta += {"node_id":"\($node_id)"}' client.temp.3 > client.temp.4
 	jq '.bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"'${vpc_cidr}'\" | attr \"address\" }}"' client.temp.4 > /etc/consul.d/client.json
 }
 

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -47,6 +47,6 @@ variable "vpc_cidr" {
 
 variable "node_id" {
   description = "A value to uniquely identify a node. This value will be added under the node_meta field for the consul agent as node_id"
-  type        = list(string)
+  type        = string
   default     = "identifier"
 }

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -44,3 +44,9 @@ variable "vpc_cidr" {
   description = "VPC CIDR"
   default     = "10.0.0.0/8"
 }
+
+variable "node_id" {
+  description = "A value to uniquely identify a node. This value will be added under the node_meta field for the consul agent as node_id"
+  type        = list(string)
+  default     = "identifier"
+}

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -48,5 +48,5 @@ variable "vpc_cidr" {
 variable "node_id" {
   description = "A value to uniquely identify a node. This value will be added under the node_meta field for the consul agent as node_id"
   type        = string
-  default     = "identifier"
+  default     = ""
 }


### PR DESCRIPTION
In AWS subnet id's are unique but the equivalent PR in azure does not share the same uniqueness since the subnet id is fixed based off the name and subscription. To handle this I am adding in a new field under node_meta for the node_id and defaulting it to `identifier`.  Leaving node_id as an empty string would cause undesired results in the node-meta field which is why it's defaulted to indentifier. This is a benign change as it will just add a tag to the services.