### PR TITLE
Add SSM var to optionally disable its use

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -26,7 +26,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -65,17 +65,18 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
-  ssh_keyname              = var.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
-  subnet_id                = module.vpc.public_subnets[0]
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
   install_demo_app         = var.install_demo_app
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  ssh_keyname              = var.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
+  ssm                      = var.ssm
+  subnet_id                = module.vpc.public_subnets[0]
   vpc_id                   = module.vpc.vpc_id
 }

--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -35,7 +35,7 @@ output "howto_connect" {
   export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
   
   To connect to the ec2 instance deployed: 
-  ${var.ssh ? "- To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
-  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}
+${var.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
+${var.ssm ? "  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}" : ""}
   EOF
 }

--- a/examples/hcp-ec2-demo/variables.tf
+++ b/examples/hcp-ec2-demo/variables.tf
@@ -40,6 +40,12 @@ variable "ssh" {
   default     = true
 }
 
+variable "ssm" {
+  type        = bool
+  description = "Whether to enable SSM to the EC2 host"
+  default     = true
+}
+
 variable "install_demo_app" {
   type        = bool
   description = "Choose to install HashiCups"

--- a/examples/hcp-ec2-demo/variables.tf
+++ b/examples/hcp-ec2-demo/variables.tf
@@ -42,7 +42,7 @@ variable "ssh" {
 
 variable "ssm" {
   type        = bool
-  description = "Whether to enable SSM to the EC2 host"
+  description = "Whether to enable SSM on the EC2 host"
   default     = true
 }
 

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -28,7 +28,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -49,7 +49,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -63,7 +63,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -85,7 +85,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -106,7 +106,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = var.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -8,6 +8,7 @@ locals {
   public_route_table_id = "{{ .PublicRouteTableID }}"
   public_subnet1        = "{{ .PublicSubnet1 }}"
   ssh                   = true
+  ssm                   = true
 }
 
 terraform {
@@ -44,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -83,18 +84,19 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
-  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
-  subnet_id                = local.public_subnet1
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
   install_demo_app         = local.install_demo_app
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
+  ssm                      = local.ssm
+  subnet_id                = local.public_subnet1
   vpc_id                   = local.vpc_id
 }
 output "consul_root_token" {
@@ -134,7 +136,7 @@ output "howto_connect" {
   export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
   
   To connect to the ec2 instance deployed: 
-  ${local.ssh ? "- To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
-  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}
+${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
+${local.ssm ? "  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}" : ""}
   EOF
 }

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -5,6 +5,7 @@ locals {
   hvn_id           = "{{ .ClusterID }}-hvn"
   install_demo_app = true
   ssh              = true
+  ssm              = true
 }
 
 terraform {
@@ -59,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -98,18 +99,19 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
-  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
-  subnet_id                = module.vpc.public_subnets[0]
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
   install_demo_app         = local.install_demo_app
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
+  ssm                      = local.ssm
+  subnet_id                = module.vpc.public_subnets[0]
   vpc_id                   = module.vpc.vpc_id
 }
 output "consul_root_token" {
@@ -149,7 +151,7 @@ output "howto_connect" {
   export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
   
   To connect to the ec2 instance deployed: 
-  ${local.ssh ? "- To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
-  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}
+${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
+${local.ssm ? "  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}" : ""}
   EOF
 }

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,7 +131,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,7 +148,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -169,7 +169,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   depends_on = [module.eks_consul_client]
 }

--- a/modules/hcp-ec2-client/intentions.tf
+++ b/modules/hcp-ec2-client/intentions.tf
@@ -11,7 +11,7 @@ resource "consul_config_entry" "service_intentions_deny" {
     ]
   })
   depends_on = [
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 
@@ -30,7 +30,7 @@ resource "consul_config_entry" "service_intentions_product_api" {
     ]
   })
   depends_on = [
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 resource "consul_config_entry" "service_intentions_frontend_publicapi" {
@@ -48,7 +48,7 @@ resource "consul_config_entry" "service_intentions_frontend_publicapi" {
     ]
   })
   depends_on = [
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 
@@ -67,7 +67,7 @@ resource "consul_config_entry" "service_intentions_ingress_frontend" {
     ]
   })
   depends_on = [
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 
@@ -86,7 +86,7 @@ resource "consul_config_entry" "service_intentions_product_db" {
     ]
   })
   depends_on = [
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 
@@ -105,6 +105,6 @@ resource "consul_config_entry" "service_intentions_payment_api" {
     ]
   })
   depends_on = [
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }

--- a/modules/hcp-ec2-client/nomad.tf
+++ b/modules/hcp-ec2-client/nomad.tf
@@ -1,5 +1,5 @@
 provider "nomad" {
-  address   = "http://${aws_instance.nomad_host[0].public_ip}:8081"
+  address   = "http://${aws_instance.host[0].public_ip}:8081"
   http_auth = "nomad:${var.root_token}"
 }
 
@@ -7,7 +7,7 @@ provider "nomad" {
 resource "time_sleep" "wait_for_client" {
   create_duration = "90s"
 
-  depends_on = [aws_instance.nomad_host]
+  depends_on = [aws_instance.host]
 }
 
 resource "nomad_job" "hashicups" {
@@ -22,7 +22,7 @@ resource "nomad_job" "hashicups" {
 
   depends_on = [
     time_sleep.wait_for_client,
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 
@@ -38,7 +38,7 @@ resource "nomad_job" "hashicups-frontend" {
   depends_on = [
     nomad_job.hashicups,
     consul_config_entry.service_default_frontend,
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 
@@ -60,7 +60,7 @@ resource "nomad_job" "hashicups-frontend-v2" {
   depends_on = [
     time_sleep.wait_15_seconds,
     consul_config_entry.service_default_frontend,
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }
 
@@ -77,6 +77,6 @@ resource "nomad_job" "hashicups-ingress" {
   depends_on = [
     nomad_job.hashicups-frontend-v2,
     nomad_job.hashicups-frontend,
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }

--- a/modules/hcp-ec2-client/output.tf
+++ b/modules/hcp-ec2-client/output.tf
@@ -1,7 +1,7 @@
 output "host_id" {
-  value = aws_instance.nomad_host[0].id
+  value = aws_instance.host[0].id
 }
 
 output "public_ip" {
-  value = aws_instance.nomad_host[0].public_ip
+  value = aws_instance.host[0].public_ip
 }

--- a/modules/hcp-ec2-client/services.tf
+++ b/modules/hcp-ec2-client/services.tf
@@ -9,6 +9,6 @@ resource "consul_config_entry" "service_default_frontend" {
     Protocol = "http"
   })
   depends_on = [
-    aws_instance.nomad_host
+    aws_instance.host
   ]
 }

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -70,6 +70,6 @@ variable "node_id" {
 
 variable "ssm" {
   type        = bool
-  description = "Whether to enable SSM to the EC2 host"
+  description = "Whether to enable SSM on the EC2 host"
   default     = true
 }

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -56,7 +56,7 @@ variable "install_demo_app" {
   description = "Choose to install the demo app"
 }
 
-#needed to setup the unique security groups per ec2 instance
+# needed to setup the unique security groups per ec2 instance
 variable "vpc_id" {
   type        = string
   description = "VPC ID"
@@ -66,4 +66,10 @@ variable "node_id" {
   description = "A value to uniquely identify a node. This value will be added under the node_meta field for the consul agent as node_id"
   type        = string
   default     = ""
+}
+
+variable "ssm" {
+  type        = bool
+  description = "Whether to enable SSM to the EC2 host"
+  default     = true
 }

--- a/scripts/ec2.snip
+++ b/scripts/ec2.snip
@@ -1,1 +1,2 @@
 ssh                   = true
+ssm                   = true

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.8\.0"
-new=0.8.1
+old="0\.8\.1"
+new=0.8.2
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -8,6 +8,7 @@ locals {
   public_route_table_id = "rtb-02b0b92efeae83c28"
   public_subnet1        = "subnet-04afc1709a875ad5d"
   ssh                   = true
+  ssm                   = true
 }
 
 terraform {
@@ -44,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -83,18 +84,19 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
-  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
-  subnet_id                = local.public_subnet1
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
   install_demo_app         = local.install_demo_app
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
+  ssm                      = local.ssm
+  subnet_id                = local.public_subnet1
   vpc_id                   = local.vpc_id
 }
 output "consul_root_token" {
@@ -134,7 +136,7 @@ output "howto_connect" {
   export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
   
   To connect to the ec2 instance deployed: 
-  ${local.ssh ? "- To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
-  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}
+${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
+${local.ssm ? "  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}" : ""}
   EOF
 }

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -5,6 +5,7 @@ locals {
   hvn_id           = "consul-quickstart-1634271483588-hvn"
   install_demo_app = true
   ssh              = true
+  ssm              = true
 }
 
 terraform {
@@ -59,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -98,18 +99,19 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
-  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
-  subnet_id                = module.vpc.public_subnets[0]
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
   install_demo_app         = local.install_demo_app
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  ssh_keyname              = local.ssh ? aws_key_pair.hcp_ec2[0].key_name : ""
+  ssm                      = local.ssm
+  subnet_id                = module.vpc.public_subnets[0]
   vpc_id                   = module.vpc.vpc_id
 }
 output "consul_root_token" {
@@ -149,7 +151,7 @@ output "howto_connect" {
   export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
   
   To connect to the ec2 instance deployed: 
-  ${local.ssh ? "- To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
-  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}
+${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
+${local.ssm ? "  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}" : ""}
   EOF
 }

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,7 +131,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   depends_on = [module.eks_consul_client]
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,7 +148,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -169,7 +169,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.1"
+  version = "~> 0.8.2"
 
   depends_on = [module.eks_consul_client]
 }


### PR DESCRIPTION
In our E2E tests, we can hit errors where the GH role does not have auth to make IAM roles. This adds an optional arg for whether to use SSM in the test.

### Testing

E2E tested with settings below. HashiCups spun up, did not have SSM:

```
locals {
  vpc_region       = "us-east-1"
  hvn_region       = "us-east-1"
  cluster_id       = "hc-ec2-cluster"
  hvn_id           = "hc-ec2-cluster-hvn"
  install_demo_app = true
  ssh              = true
  ssm              = false
}
```