### PR TITLE
Change root module to depend on peering

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -26,7 +26,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -65,7 +65,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -79,6 +79,4 @@ module "aws_ec2_consul_client" {
   ssm                      = var.ssm
   subnet_id                = module.vpc.public_subnets[0]
   vpc_id                   = module.vpc.vpc_id
-
-  depends_on = [module.aws_hcp_consul]
 }

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -28,7 +28,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -49,21 +49,21 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
-  private_subnet_ids       = module.vpc.private_subnets
-  public_subnet_ids        = module.vpc.public_subnets
-  vpc_id                   = module.vpc.vpc_id
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_gossip_key        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
   client_retry_join        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  region                   = var.vpc_region
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  private_subnet_ids       = module.vpc.private_subnets
+  public_subnet_ids        = module.vpc.public_subnets
+  region                   = var.vpc_region
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  vpc_id                   = module.vpc.vpc_id
 }

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -63,7 +63,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -85,17 +85,16 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.5"
-
-  cluster_id       = hcp_consul_cluster.main.cluster_id
-  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  k8s_api_endpoint = var.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
-  consul_version   = hcp_consul_cluster.main.consul_version
+  version = "~> 0.8.6"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  cluster_id            = hcp_consul_cluster.main.cluster_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  consul_hosts          = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  consul_version        = hcp_consul_cluster.main.consul_version
   datacenter            = hcp_consul_cluster.main.datacenter
   gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+  k8s_api_endpoint      = var.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
 
   # The EKS node group will fail to create if the clients are
   # created at the same time. This forces the client to wait until
@@ -106,7 +105,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = var.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -84,7 +84,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -98,8 +98,6 @@ module "aws_ec2_consul_client" {
   ssm                      = local.ssm
   subnet_id                = local.public_subnet1
   vpc_id                   = local.vpc_id
-
-  depends_on = [module.aws_hcp_consul]
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -99,7 +99,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -113,8 +113,6 @@ module "aws_ec2_consul_client" {
   ssm                      = local.ssm
   subnet_id                = module.vpc.public_subnets[0]
   vpc_id                   = module.vpc.vpc_id
-
-  depends_on = [module.aws_hcp_consul]
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,23 +66,23 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
-  private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
-  public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
-  vpc_id                   = local.vpc_id
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_gossip_key        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
   client_retry_join        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  region                   = local.vpc_region
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
+  public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
+  region                   = local.vpc_region
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  vpc_id                   = local.vpc_id
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,23 +81,23 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
-  private_subnet_ids       = module.vpc.private_subnets
-  public_subnet_ids        = module.vpc.public_subnets
-  vpc_id                   = module.vpc.vpc_id
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_gossip_key        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
   client_retry_join        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  region                   = local.vpc_region
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  private_subnet_ids       = module.vpc.private_subnets
+  public_subnet_ids        = module.vpc.public_subnets
+  region                   = local.vpc_region
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  vpc_id                   = module.vpc.vpc_id
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,17 +131,16 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.5"
-
-  cluster_id       = hcp_consul_cluster.main.cluster_id
-  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  k8s_api_endpoint = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
-  consul_version   = hcp_consul_cluster.main.consul_version
+  version = "~> 0.8.6"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  cluster_id            = hcp_consul_cluster.main.cluster_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  consul_hosts          = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  consul_version        = hcp_consul_cluster.main.consul_version
   datacenter            = hcp_consul_cluster.main.datacenter
   gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+  k8s_api_endpoint      = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
 
   # The EKS node group will fail to create if the clients are
   # created at the same time. This forces the client to wait until
@@ -152,7 +151,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,17 +148,16 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.5"
-
-  cluster_id       = hcp_consul_cluster.main.cluster_id
-  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  k8s_api_endpoint = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
-  consul_version   = hcp_consul_cluster.main.consul_version
+  version = "~> 0.8.6"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  cluster_id            = hcp_consul_cluster.main.cluster_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  consul_hosts          = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  consul_version        = hcp_consul_cluster.main.consul_version
   datacenter            = hcp_consul_cluster.main.datacenter
   gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+  k8s_api_endpoint      = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
 
   # The EKS node group will fail to create if the clients are
   # created at the same time. This forces the client to wait until
@@ -169,7 +168,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   depends_on = [module.eks_consul_client]
 }

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,6 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   auto_accept               = true
 }
 
-
 data "aws_subnet" "selected" {
   count = length(var.subnet_ids)
   id    = var.subnet_ids[count.index]
@@ -70,11 +69,12 @@ data "aws_subnet" "selected" {
 
 resource "hcp_hvn_route" "peering_route" {
   count            = length(var.subnet_ids)
-  depends_on       = [aws_vpc_peering_connection_accepter.peer]
   hvn_link         = var.hvn.self_link
   hvn_route_id     = var.subnet_ids[count.index]
   destination_cidr = data.aws_subnet.selected[count.index].cidr_block
   target_link      = hcp_aws_network_peering.default.self_link
+
+  depends_on = [aws_vpc_peering_connection_accepter.peer]
 }
 
 resource "aws_route" "peering" {

--- a/output.tf
+++ b/output.tf
@@ -1,4 +1,9 @@
 output "security_group_id" {
   description = "Newly created AWS security group that allow Consul client communication, if 'security_group_ids' was not provided."
   value       = length(var.security_group_ids) == 0 ? aws_security_group.hcp_consul[0].id : ""
+
+  # This is here because so Consul clients wait until the HVN <> VPC peering completes and an HVN to VPC route exists.
+  # If Consul clients try to connect before this peering is accepted and configured, clients will not be able to
+  # communicate back to the HCP Consul server and Consul client calls will fail.
+  depends_on = [hcp_hvn_route.peering_route]
 }

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.8\.4"
-new=0.8.5
+old="0\.8\.5"
+new=0.8.6
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -84,7 +84,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -98,8 +98,6 @@ module "aws_ec2_consul_client" {
   ssm                      = local.ssm
   subnet_id                = local.public_subnet1
   vpc_id                   = local.vpc_id
-
-  depends_on = [module.aws_hcp_consul]
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -99,7 +99,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -113,8 +113,6 @@ module "aws_ec2_consul_client" {
   ssm                      = local.ssm
   subnet_id                = module.vpc.public_subnets[0]
   vpc_id                   = module.vpc.vpc_id
-
-  depends_on = [module.aws_hcp_consul]
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,23 +66,23 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
-  private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
-  public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
-  vpc_id                   = local.vpc_id
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_gossip_key        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
   client_retry_join        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  region                   = local.vpc_region
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
+  public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
+  region                   = local.vpc_region
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  vpc_id                   = local.vpc_id
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,23 +81,23 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
-  private_subnet_ids       = module.vpc.private_subnets
-  public_subnet_ids        = module.vpc.public_subnets
-  vpc_id                   = module.vpc.vpc_id
-  security_group_id        = module.aws_hcp_consul.security_group_id
-  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
-  client_config_file       = hcp_consul_cluster.main.consul_config_file
+  allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
+  client_config_file       = hcp_consul_cluster.main.consul_config_file
   client_gossip_key        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
   client_retry_join        = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  region                   = local.vpc_region
-  root_token               = hcp_consul_cluster_root_token.token.secret_id
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  private_subnet_ids       = module.vpc.private_subnets
+  public_subnet_ids        = module.vpc.public_subnets
+  region                   = local.vpc_region
+  root_token               = hcp_consul_cluster_root_token.token.secret_id
+  security_group_id        = module.aws_hcp_consul.security_group_id
+  vpc_id                   = module.vpc.vpc_id
 }
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,17 +131,16 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.5"
-
-  cluster_id       = hcp_consul_cluster.main.cluster_id
-  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  k8s_api_endpoint = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
-  consul_version   = hcp_consul_cluster.main.consul_version
+  version = "~> 0.8.6"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  cluster_id            = hcp_consul_cluster.main.cluster_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  consul_hosts          = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  consul_version        = hcp_consul_cluster.main.consul_version
   datacenter            = hcp_consul_cluster.main.datacenter
   gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+  k8s_api_endpoint      = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
 
   # The EKS node group will fail to create if the clients are
   # created at the same time. This forces the client to wait until
@@ -152,7 +151,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   depends_on = [module.eks_consul_client]
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,17 +148,16 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.5"
-
-  cluster_id       = hcp_consul_cluster.main.cluster_id
-  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
-  k8s_api_endpoint = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
-  consul_version   = hcp_consul_cluster.main.consul_version
+  version = "~> 0.8.6"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  cluster_id            = hcp_consul_cluster.main.cluster_id
   consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  consul_hosts          = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  consul_version        = hcp_consul_cluster.main.consul_version
   datacenter            = hcp_consul_cluster.main.datacenter
   gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+  k8s_api_endpoint      = local.install_eks_cluster ? module.eks[0].cluster_endpoint : ""
 
   # The EKS node group will fail to create if the clients are
   # created at the same time. This forces the client to wait until
@@ -169,7 +168,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.5"
+  version = "~> 0.8.6"
 
   depends_on = [module.eks_consul_client]
 }


### PR DESCRIPTION
I noticed that we are deploying intentions to HCP Consul before the HVN<>VPC peering is complete. In some cases, we are deploying the clients and trying to issue Nomad jobs, before the peering is complete. This changes it so all peering just waits on the peering to be up and running and finished.

### Testing

Spun up HashiCups on EC2 instance 
