### PR TITLE
Add EC2/ECS dependencies on IGW

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -9,12 +9,12 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.10.0"
 
-  name                 = "${var.cluster_id}-vpc"
-  cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
-  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  private_subnets      = []
+  cidr                 = "10.0.0.0/16"
   enable_dns_hostnames = true
+  name                 = "${var.cluster_id}-vpc"
+  private_subnets      = []
+  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 resource "hcp_hvn" "main" {
@@ -26,7 +26,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -51,27 +51,30 @@ resource "tls_private_key" "ssh" {
 }
 
 resource "aws_key_pair" "hcp_ec2" {
-  count      = var.ssh ? 1 : 0
-  key_name   = "hcp-ec2-key"
+  count = var.ssh ? 1 : 0
+
   public_key = tls_private_key.ssh.public_key_openssh
+  key_name   = "hcp-ec2-key"
 }
 
 resource "local_file" "ssh_key" {
-  count           = var.ssh ? 1 : 0
-  filename        = "${path.module}/${aws_key_pair.hcp_ec2[0].key_name}.pem"
+  count = var.ssh ? 1 : 0
+
   content         = tls_private_key.ssh.private_key_pem
   file_permission = "400"
+  filename        = "${path.module}/${aws_key_pair.hcp_ec2[0].key_name}.pem"
 }
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
+  igw_id                   = module.vpc.igw_id
   install_demo_app         = var.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -28,7 +28,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -49,7 +49,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -60,6 +60,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  igw_id                   = module.vpc.igw_id
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
   region                   = var.vpc_region

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -63,7 +63,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -85,7 +85,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -105,7 +105,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = var.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   depends_on = [module.eks_consul_client]
 }

--- a/examples/hcp-eks-demo/variables.tf
+++ b/examples/hcp-eks-demo/variables.tf
@@ -4,16 +4,10 @@ variable "cluster_id" {
   default     = "cluster-eks-demo"
 }
 
-variable "vpc_region" {
+variable "hvn_cidr_block" {
   type        = string
-  description = "The AWS region to create resources in"
-  default     = "us-west-2"
-}
-
-variable "hvn_region" {
-  type        = string
-  description = "The HCP region to create resources in"
-  default     = "us-west-2"
+  description = "The CIDR range to create the HCP HVN with"
+  default     = "172.25.32.0/20"
 }
 
 variable "hvn_id" {
@@ -22,16 +16,10 @@ variable "hvn_id" {
   default     = "cluster-eks-demo-hvn"
 }
 
-variable "hvn_cidr_block" {
+variable "hvn_region" {
   type        = string
-  description = "The CIDR range to create the HCP HVN with"
-  default     = "172.25.32.0/20"
-}
-
-variable "tier" {
-  type        = string
-  description = "The HCP Consul tier to use when creating a Consul cluster"
-  default     = "development"
+  description = "The HCP region to create resources in"
+  default     = "us-west-2"
 }
 
 variable "install_demo_app" {
@@ -44,4 +32,16 @@ variable "install_eks_cluster" {
   type        = string
   description = "Choose if you want an eks cluster to be provisioned"
   default     = true
+}
+
+variable "tier" {
+  type        = string
+  description = "The HCP Consul tier to use when creating a Consul cluster"
+  default     = "development"
+}
+
+variable "vpc_region" {
+  type        = string
+  description = "The AWS region to create resources in"
+  default     = "us-west-2"
 }

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -43,12 +43,12 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.10.0"
 
-  name                 = "${local.cluster_id}-vpc"
-  cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
-  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  private_subnets      = []
+  cidr                 = "10.0.0.0/16"
   enable_dns_hostnames = true
+  name                 = "${local.cluster_id}-vpc"
+  private_subnets      = []
+  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 resource "hcp_hvn" "main" {
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -85,27 +85,30 @@ resource "tls_private_key" "ssh" {
 }
 
 resource "aws_key_pair" "hcp_ec2" {
-  count      = local.ssh ? 1 : 0
-  key_name   = "hcp-ec2-key"
+  count = local.ssh ? 1 : 0
+
   public_key = tls_private_key.ssh.public_key_openssh
+  key_name   = "hcp-ec2-key"
 }
 
 resource "local_file" "ssh_key" {
-  count           = local.ssh ? 1 : 0
-  filename        = "${path.module}/${aws_key_pair.hcp_ec2[0].key_name}.pem"
+  count = local.ssh ? 1 : 0
+
   content         = tls_private_key.ssh.private_key_pem
   file_permission = "400"
+  filename        = "${path.module}/${aws_key_pair.hcp_ec2[0].key_name}.pem"
 }
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
+  igw_id                   = module.vpc.igw_id
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -77,6 +77,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  igw_id                   = module.vpc.igw_id
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -92,6 +92,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  igw_id                   = module.vpc.igw_id
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
   region                   = local.vpc_region

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,7 +131,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -151,7 +151,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,7 +148,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -168,7 +168,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   depends_on = [module.eks_consul_client]
 }

--- a/modules/hcp-ec2-client/intentions.tf
+++ b/modules/hcp-ec2-client/intentions.tf
@@ -10,8 +10,6 @@ resource "consul_config_entry" "service_intentions_deny" {
       }
     ]
   })
-
-  depends_on = [time_sleep.wait_for_startup]
 }
 
 resource "consul_config_entry" "service_intentions_product_api" {
@@ -28,8 +26,6 @@ resource "consul_config_entry" "service_intentions_product_api" {
       },
     ]
   })
-
-  depends_on = [time_sleep.wait_for_startup]
 }
 resource "consul_config_entry" "service_intentions_frontend_publicapi" {
   name = "public-api"
@@ -45,8 +41,6 @@ resource "consul_config_entry" "service_intentions_frontend_publicapi" {
       },
     ]
   })
-
-  depends_on = [time_sleep.wait_for_startup]
 }
 
 resource "consul_config_entry" "service_intentions_ingress_frontend" {
@@ -63,8 +57,6 @@ resource "consul_config_entry" "service_intentions_ingress_frontend" {
       },
     ]
   })
-
-  depends_on = [time_sleep.wait_for_startup]
 }
 
 resource "consul_config_entry" "service_intentions_product_db" {
@@ -81,8 +73,6 @@ resource "consul_config_entry" "service_intentions_product_db" {
       },
     ]
   })
-
-  depends_on = [time_sleep.wait_for_startup]
 }
 
 resource "consul_config_entry" "service_intentions_payment_api" {
@@ -99,6 +89,4 @@ resource "consul_config_entry" "service_intentions_payment_api" {
       },
     ]
   })
-
-  depends_on = [time_sleep.wait_for_startup]
 }

--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -93,7 +93,7 @@ resource "aws_instance" "host" {
   count = 1
 
   ami                         = data.aws_ami.ubuntu.id
-  associate_public_ip_address = true
+  associate_public_ip_address = length(var.igw_id) > 0
   iam_instance_profile        = length(aws_iam_instance_profile.hcp_ec2) >= 1 ? aws_iam_instance_profile.hcp_ec2[0].name : null
   instance_type               = "t3.medium"
   key_name                    = var.ssh_keyname

--- a/modules/hcp-ec2-client/services.tf
+++ b/modules/hcp-ec2-client/services.tf
@@ -8,6 +8,4 @@ resource "consul_config_entry" "service_default_frontend" {
   config_json = jsonencode({
     Protocol = "http"
   })
-
-  depends_on = [time_sleep.wait_for_startup]
 }

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -1,6 +1,7 @@
-variable "subnet_id" {
-  type        = string
-  description = "The subnet ID to create EC2 clients in"
+variable "allowed_http_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections over 8080"
+  type        = list(string)
+  default     = []
 }
 
 variable "allowed_ssh_cidr_blocks" {
@@ -9,15 +10,9 @@ variable "allowed_ssh_cidr_blocks" {
   default     = []
 }
 
-variable "ssh_keyname" {
-  description = "key pair name for ssh connection"
-  default     = ""
-}
-
-variable "allowed_http_cidr_blocks" {
-  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections over 8080"
-  type        = list(string)
-  default     = []
+variable "client_ca_file" {
+  type        = string
+  description = "The Consul client CA file provided by HCP"
 }
 
 variable "client_config_file" {
@@ -25,29 +20,9 @@ variable "client_config_file" {
   description = "The client config file provided by HCP"
 }
 
-variable "client_ca_file" {
-  type        = string
-  description = "The Consul client CA file provided by HCP"
-}
-
-variable "root_token" {
-  type        = string
-  description = "The Consul Secret ID of the Consul root token"
-}
-
 variable "consul_version" {
   type        = string
   description = "The Consul version of the HCP servers"
-}
-
-variable "security_group_id" {
-  type = string
-}
-
-variable "vpc_cidr" {
-  type        = string
-  description = "VPC CIDR"
-  default     = "10.0.0.0/8"
 }
 
 variable "install_demo_app" {
@@ -56,10 +31,9 @@ variable "install_demo_app" {
   description = "Choose to install the demo app"
 }
 
-# needed to setup the unique security groups per ec2 instance
-variable "vpc_id" {
+variable "igw_id" {
   type        = string
-  description = "VPC ID"
+  description = "The ID of the VPC's Internet Gateway. Here to ensure the instance is deleted and public IP freed before attempting to destroy the Internet Gateway which will otherwise fail"
 }
 
 variable "node_id" {
@@ -68,8 +42,38 @@ variable "node_id" {
   default     = ""
 }
 
+variable "root_token" {
+  type        = string
+  description = "The Consul Secret ID of the Consul root token"
+}
+
+variable "security_group_id" {
+  type = string
+}
+
+variable "ssh_keyname" {
+  description = "key pair name for ssh connection"
+  default     = ""
+}
+
 variable "ssm" {
   type        = bool
   description = "Whether to enable SSM on the EC2 host"
   default     = true
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "The subnet ID to create EC2 clients in"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "VPC CIDR"
+  default     = "10.0.0.0/8"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
 }

--- a/modules/hcp-ecs-client/main.tf
+++ b/modules/hcp-ecs-client/main.tf
@@ -40,6 +40,8 @@ resource "aws_security_group_rule" "allow_http_inbound" {
 resource "aws_ecs_cluster" "clients" {
   name               = "hcp-ecs-cluster-${random_id.id.dec}"
   capacity_providers = ["FARGATE"]
+
+  depends_on = [var.igw_id]
 }
 
 resource "random_id" "id" {

--- a/modules/hcp-ecs-client/variables.tf
+++ b/modules/hcp-ecs-client/variables.tf
@@ -30,6 +30,11 @@ variable "client_config_file" {
   description = "The client config file provided by HCP"
 }
 
+variable "igw_id" {
+  type        = string
+  description = "The ID of the VPC's Internet Gateway. Here to ensure the cluster and IP are freed before attempting to destroy the Internet Gateway which will otherwise fail"
+}
+
 variable "client_ca_file" {
   type        = string
   description = "The Consul client CA file provided by HCP"

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.8\.5"
-new=0.8.6
+old="0\.8\.6"
+new=0.8.7
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -43,12 +43,12 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.10.0"
 
-  name                 = "${local.cluster_id}-vpc"
-  cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
-  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  private_subnets      = []
+  cidr                 = "10.0.0.0/16"
   enable_dns_hostnames = true
+  name                 = "${local.cluster_id}-vpc"
+  private_subnets      = []
+  public_subnets       = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 resource "hcp_hvn" "main" {
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -85,27 +85,30 @@ resource "tls_private_key" "ssh" {
 }
 
 resource "aws_key_pair" "hcp_ec2" {
-  count      = local.ssh ? 1 : 0
-  key_name   = "hcp-ec2-key"
+  count = local.ssh ? 1 : 0
+
   public_key = tls_private_key.ssh.public_key_openssh
+  key_name   = "hcp-ec2-key"
 }
 
 resource "local_file" "ssh_key" {
-  count           = local.ssh ? 1 : 0
-  filename        = "${path.module}/${aws_key_pair.hcp_ec2[0].key_name}.pem"
+  count = local.ssh ? 1 : 0
+
   content         = tls_private_key.ssh.private_key_pem
   file_permission = "400"
+  filename        = "${path.module}/${aws_key_pair.hcp_ec2[0].key_name}.pem"
 }
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
+  igw_id                   = module.vpc.igw_id
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -77,6 +77,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  igw_id                   = module.vpc.igw_id
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -92,6 +92,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  igw_id                   = module.vpc.igw_id
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
   region                   = local.vpc_region

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,7 +131,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -151,7 +151,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   depends_on = [module.eks_consul_client]
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,7 +148,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -168,7 +168,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.6"
+  version = "~> 0.8.7"
 
   depends_on = [module.eks_consul_client]
 }


### PR DESCRIPTION
We're creating an internet gateway and IPs and associating those with the ECS cluster or EC2 instance but not deleting the instance of cluster before the internet gateway (which then fails). This adds an explicit dependency on the IGW. Best ref I could find: https://github.com/hashicorp/terraform/issues/497#issuecomment-71674263