### PR TITLE
Fix Ingress Gateway Consul registration

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -26,7 +26,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -54,7 +54,7 @@ resource "aws_key_pair" "hcp_ec2" {
   count = var.ssh ? 1 : 0
 
   public_key = tls_private_key.ssh.public_key_openssh
-  key_name   = "hcp-ec2-key"
+  key_name   = "hcp-ec2-key-${var.cluster_id}"
 }
 
 resource "local_file" "ssh_key" {
@@ -67,14 +67,14 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   install_demo_app         = var.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -60,7 +60,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
   region                   = var.vpc_region

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -28,7 +28,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -49,7 +49,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -63,7 +63,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -85,7 +85,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -105,7 +105,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = var.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -73,7 +73,7 @@ resource "aws_key_pair" "hcp_ec2" {
   count = local.ssh ? 1 : 0
 
   public_key = tls_private_key.ssh.public_key_openssh
-  key_name   = "hcp-ec2-key"
+  key_name   = "hcp-ec2-key-${local.cluster_id}"
 }
 
 resource "local_file" "ssh_key" {
@@ -86,14 +86,14 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -88,7 +88,7 @@ resource "aws_key_pair" "hcp_ec2" {
   count = local.ssh ? 1 : 0
 
   public_key = tls_private_key.ssh.public_key_openssh
-  key_name   = "hcp-ec2-key"
+  key_name   = "hcp-ec2-key-${local.cluster_id}"
 }
 
 resource "local_file" "ssh_key" {
@@ -101,14 +101,14 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -77,7 +77,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -92,7 +92,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
   region                   = local.vpc_region

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,7 +131,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -151,7 +151,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,7 +148,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -168,7 +168,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   depends_on = [module.eks_consul_client]
 }

--- a/main.tf
+++ b/main.tf
@@ -98,15 +98,17 @@ resource "aws_security_group_rule" "hcp_consul_existing_grp" {
 
 # If no security_group_ids were provided, create a new security_group.
 resource "aws_security_group" "hcp_consul" {
-  count       = length(var.security_group_ids) == 0 ? 1 : 0
+  count = length(var.security_group_ids) == 0 ? 1 : 0
+
   name_prefix = "hcp_consul"
   description = "HCP Consul security group"
   vpc_id      = data.aws_vpc.selected.id
 }
 
 # If no security_group_ids were provided, use the new security_group.
-resource "aws_security_group_rule" "hcp_consul_new_grp" {
-  count             = length(var.security_group_ids) == 0 ? length(local.ingress_consul_rules) : 0
+resource "aws_security_group_rule" "allow_lan_consul_gossip" {
+  count = length(var.security_group_ids) == 0 ? length(local.ingress_consul_rules) : 0
+
   description       = local.ingress_consul_rules[count.index].description
   protocol          = local.ingress_consul_rules[count.index].protocol
   security_group_id = aws_security_group.hcp_consul[0].id

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,8 @@ data "aws_subnet" "selected" {
 }
 
 resource "hcp_hvn_route" "peering_route" {
-  count            = length(var.subnet_ids)
+  count = length(var.subnet_ids)
+
   hvn_link         = var.hvn.self_link
   hvn_route_id     = var.subnet_ids[count.index]
   destination_cidr = data.aws_subnet.selected[count.index].cidr_block
@@ -78,7 +79,8 @@ resource "hcp_hvn_route" "peering_route" {
 }
 
 resource "aws_route" "peering" {
-  count                     = length(var.route_table_ids)
+  count = length(var.route_table_ids)
+
   route_table_id            = var.route_table_ids[count.index]
   destination_cidr_block    = var.hvn.cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.vpc_peering_connection_id
@@ -86,7 +88,8 @@ resource "aws_route" "peering" {
 
 # If a list of security_group_ids was provided, set rules on those.
 resource "aws_security_group_rule" "hcp_consul_existing_grp" {
-  count             = length(local.hcp_consul_security_groups)
+  count = length(local.hcp_consul_security_groups)
+
   description       = local.hcp_consul_security_groups[count.index].description
   protocol          = local.hcp_consul_security_groups[count.index].protocol
   security_group_id = local.hcp_consul_security_groups[count.index].security_group_id

--- a/modules/hcp-ec2-client/intentions.tf
+++ b/modules/hcp-ec2-client/intentions.tf
@@ -1,4 +1,6 @@
 resource "consul_config_entry" "service_intentions_deny" {
+  count = var.install_demo_app ? 1 : 0
+
   name = "*"
   kind = "service-intentions"
 
@@ -13,6 +15,8 @@ resource "consul_config_entry" "service_intentions_deny" {
 }
 
 resource "consul_config_entry" "service_intentions_product_api" {
+  count = var.install_demo_app ? 1 : 0
+
   name = "product-api"
   kind = "service-intentions"
 
@@ -28,6 +32,8 @@ resource "consul_config_entry" "service_intentions_product_api" {
   })
 }
 resource "consul_config_entry" "service_intentions_frontend_publicapi" {
+  count = var.install_demo_app ? 1 : 0
+
   name = "public-api"
   kind = "service-intentions"
 
@@ -44,6 +50,8 @@ resource "consul_config_entry" "service_intentions_frontend_publicapi" {
 }
 
 resource "consul_config_entry" "service_intentions_ingress_frontend" {
+  count = var.install_demo_app ? 1 : 0
+
   name = "frontend"
   kind = "service-intentions"
 
@@ -60,6 +68,8 @@ resource "consul_config_entry" "service_intentions_ingress_frontend" {
 }
 
 resource "consul_config_entry" "service_intentions_product_db" {
+  count = var.install_demo_app ? 1 : 0
+
   name = "product-db"
   kind = "service-intentions"
 
@@ -76,6 +86,8 @@ resource "consul_config_entry" "service_intentions_product_db" {
 }
 
 resource "consul_config_entry" "service_intentions_payment_api" {
+  count = var.install_demo_app ? 1 : 0
+
   name = "payment-api"
   kind = "service-intentions"
 

--- a/modules/hcp-ec2-client/main.tf
+++ b/modules/hcp-ec2-client/main.tf
@@ -90,10 +90,8 @@ resource "aws_iam_instance_profile" "hcp_ec2" {
 
 # Create the Consul and Nomad client
 resource "aws_instance" "host" {
-  count = 1
-
   ami                         = data.aws_ami.ubuntu.id
-  associate_public_ip_address = length(var.igw_id) > 0
+  associate_public_ip_address = true
   iam_instance_profile        = length(aws_iam_instance_profile.hcp_ec2) >= 1 ? aws_iam_instance_profile.hcp_ec2[0].name : null
   instance_type               = "t3.medium"
   key_name                    = var.ssh_keyname
@@ -135,6 +133,7 @@ resource "aws_instance" "host" {
     prevent_destroy       = false
   }
 
+  depends_on = [var.nat_public_ips]
 }
 
 resource "random_id" "id" {

--- a/modules/hcp-ec2-client/nomad.tf
+++ b/modules/hcp-ec2-client/nomad.tf
@@ -1,11 +1,11 @@
 provider "nomad" {
-  address   = "http://${aws_instance.host[0].public_ip}:8081"
+  address   = "http://${aws_instance.host.public_ip}:8081"
   http_auth = "nomad:${var.root_token}"
 }
 
 # wait for Consul and Nomad services to be ready
 resource "time_sleep" "wait_for_startup" {
-  create_duration = "90s"
+  create_duration = "2m"
 
   depends_on = [aws_instance.host]
 }
@@ -13,28 +13,41 @@ resource "time_sleep" "wait_for_startup" {
 resource "nomad_job" "hashicups" {
   count = var.install_demo_app ? 1 : 0
 
-  provider = nomad
-  jobspec  = file("${path.module}/templates/hashicups.nomad")
-
-  hcl2 {
-    enabled = true
-  }
-
-  depends_on = [time_sleep.wait_for_startup]
-}
-
-resource "nomad_job" "hashicups_frontend" {
-  count    = var.install_demo_app ? 1 : 0
-  provider = nomad
-  jobspec  = file("${path.module}/templates/hashicups-frontend.nomad")
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/hashicups.nomad")
+  deregister_on_destroy = false
 
   hcl2 {
     enabled = true
   }
 
   depends_on = [
-    time_sleep.wait_for_startup,
-    consul_config_entry.service_default_frontend
+    aws_instance.host,
+    aws_security_group_rule.allow_nomad_inbound,
+    consul_config_entry.service_default_payment_api,
+    consul_config_entry.service_default_product_api,
+    consul_config_entry.service_default_product_db,
+    consul_config_entry.service_default_public_api,
+    time_sleep.wait_for_startup
+  ]
+}
+
+resource "nomad_job" "hashicups_frontend" {
+  count = var.install_demo_app ? 1 : 0
+
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/hashicups-frontend.nomad")
+  deregister_on_destroy = false
+
+  hcl2 {
+    enabled = true
+  }
+
+  depends_on = [
+    aws_instance.host,
+    aws_security_group_rule.allow_nomad_inbound,
+    consul_config_entry.service_default_frontend,
+    time_sleep.wait_for_startup
   ]
 }
 
@@ -45,25 +58,39 @@ resource "time_sleep" "wait_for_frontend" {
 }
 
 resource "nomad_job" "hashicups_frontend_v2" {
-  count    = var.install_demo_app ? 1 : 0
-  provider = nomad
-  jobspec  = file("${path.module}/templates/hashicups-frontend-v2.nomad")
+  count = var.install_demo_app ? 1 : 0
+
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/hashicups-frontend-v2.nomad")
+  deregister_on_destroy = false
 
   hcl2 {
     enabled = true
   }
 
-  depends_on = [time_sleep.wait_for_frontend]
+  depends_on = [
+    aws_instance.host,
+    aws_security_group_rule.allow_nomad_inbound,
+    consul_config_entry.service_default_frontend,
+    time_sleep.wait_for_frontend
+  ]
 }
 
 resource "nomad_job" "ingress" {
-  count    = var.install_demo_app ? 1 : 0
-  provider = nomad
-  jobspec  = file("${path.module}/templates/ingress.nomad")
+  count = var.install_demo_app ? 1 : 0
+
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/ingress.nomad")
+  deregister_on_destroy = false
 
   hcl2 {
     enabled = true
   }
 
-  depends_on = [nomad_job.hashicups_frontend_v2]
+  depends_on = [
+    aws_instance.host,
+    aws_security_group_rule.allow_nomad_inbound,
+    consul_config_entry.ingress_gateway,
+    time_sleep.wait_for_frontend
+  ]
 }

--- a/modules/hcp-ec2-client/nomad.tf
+++ b/modules/hcp-ec2-client/nomad.tf
@@ -13,8 +13,9 @@ resource "time_sleep" "wait_for_startup" {
 resource "nomad_job" "hashicups" {
   count = var.install_demo_app ? 1 : 0
 
-  provider = nomad
-  jobspec  = file("${path.module}/templates/hashicups.nomad")
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/hashicups.nomad")
+  deregister_on_destroy = false
 
   hcl2 {
     enabled = true
@@ -30,8 +31,9 @@ resource "nomad_job" "hashicups" {
 resource "nomad_job" "hashicups_frontend" {
   count = var.install_demo_app ? 1 : 0
 
-  provider = nomad
-  jobspec  = file("${path.module}/templates/hashicups-frontend.nomad")
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/hashicups-frontend.nomad")
+  deregister_on_destroy = false
 
   hcl2 {
     enabled = true
@@ -54,8 +56,9 @@ resource "time_sleep" "wait_for_frontend" {
 resource "nomad_job" "hashicups_frontend_v2" {
   count = var.install_demo_app ? 1 : 0
 
-  provider = nomad
-  jobspec  = file("${path.module}/templates/hashicups-frontend-v2.nomad")
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/hashicups-frontend-v2.nomad")
+  deregister_on_destroy = false
 
   hcl2 {
     enabled = true
@@ -72,8 +75,9 @@ resource "nomad_job" "hashicups_frontend_v2" {
 resource "nomad_job" "ingress" {
   count = var.install_demo_app ? 1 : 0
 
-  provider = nomad
-  jobspec  = file("${path.module}/templates/ingress.nomad")
+  provider              = nomad
+  jobspec               = file("${path.module}/templates/ingress.nomad")
+  deregister_on_destroy = false
 
   hcl2 {
     enabled = true

--- a/modules/hcp-ec2-client/nomad.tf
+++ b/modules/hcp-ec2-client/nomad.tf
@@ -13,9 +13,8 @@ resource "time_sleep" "wait_for_startup" {
 resource "nomad_job" "hashicups" {
   count = var.install_demo_app ? 1 : 0
 
-  provider              = nomad
-  jobspec               = file("${path.module}/templates/hashicups.nomad")
-  deregister_on_destroy = false
+  provider = nomad
+  jobspec  = file("${path.module}/templates/hashicups.nomad")
 
   hcl2 {
     enabled = true
@@ -24,10 +23,6 @@ resource "nomad_job" "hashicups" {
   depends_on = [
     aws_instance.host,
     aws_security_group_rule.allow_nomad_inbound,
-    consul_config_entry.service_default_payment_api,
-    consul_config_entry.service_default_product_api,
-    consul_config_entry.service_default_product_db,
-    consul_config_entry.service_default_public_api,
     time_sleep.wait_for_startup
   ]
 }
@@ -35,9 +30,8 @@ resource "nomad_job" "hashicups" {
 resource "nomad_job" "hashicups_frontend" {
   count = var.install_demo_app ? 1 : 0
 
-  provider              = nomad
-  jobspec               = file("${path.module}/templates/hashicups-frontend.nomad")
-  deregister_on_destroy = false
+  provider = nomad
+  jobspec  = file("${path.module}/templates/hashicups-frontend.nomad")
 
   hcl2 {
     enabled = true
@@ -54,15 +48,14 @@ resource "nomad_job" "hashicups_frontend" {
 resource "time_sleep" "wait_for_frontend" {
   depends_on = [nomad_job.hashicups_frontend]
 
-  create_duration = "15s"
+  create_duration = "30s"
 }
 
 resource "nomad_job" "hashicups_frontend_v2" {
   count = var.install_demo_app ? 1 : 0
 
-  provider              = nomad
-  jobspec               = file("${path.module}/templates/hashicups-frontend-v2.nomad")
-  deregister_on_destroy = false
+  provider = nomad
+  jobspec  = file("${path.module}/templates/hashicups-frontend-v2.nomad")
 
   hcl2 {
     enabled = true
@@ -79,9 +72,8 @@ resource "nomad_job" "hashicups_frontend_v2" {
 resource "nomad_job" "ingress" {
   count = var.install_demo_app ? 1 : 0
 
-  provider              = nomad
-  jobspec               = file("${path.module}/templates/ingress.nomad")
-  deregister_on_destroy = false
+  provider = nomad
+  jobspec  = file("${path.module}/templates/ingress.nomad")
 
   hcl2 {
     enabled = true

--- a/modules/hcp-ec2-client/output.tf
+++ b/modules/hcp-ec2-client/output.tf
@@ -1,7 +1,7 @@
 output "host_id" {
-  value = aws_instance.host[0].id
+  value = aws_instance.host.id
 }
 
 output "public_ip" {
-  value = aws_instance.host[0].public_ip
+  value = aws_instance.host.public_ip
 }

--- a/modules/hcp-ec2-client/services.tf
+++ b/modules/hcp-ec2-client/services.tf
@@ -1,8 +1,95 @@
 # This is needed for a tutorial on blue green deployments.
 # This helps show the functionality to make it happen and 
 # hide some of the complexity like service defaults
+resource "consul_config_entry" "proxy_defaults" {
+  count = var.install_demo_app ? 1 : 0
+
+  name = "global"
+  kind = "proxy-defaults"
+
+  config_json = jsonencode({
+    Config = {
+      protocol = "http"
+    }
+  })
+}
+
 resource "consul_config_entry" "service_default_frontend" {
+  count = var.install_demo_app ? 1 : 0
+
   name = "frontend"
+  kind = "service-defaults"
+
+  config_json = jsonencode({
+    Protocol = "http"
+  })
+}
+
+# Unforunately, we have to pre-register the Ingress Gateway in Consul before
+# the Nomad service starts (for now). Otherwise, destroys will fail with:
+# "frontend" has protocol "tcp", which does not match defined listener protocol "http")
+# https://github.com/hashicorp/nomad/issues/8647#issuecomment-785484553
+resource "consul_config_entry" "ingress_gateway" {
+  count = var.install_demo_app ? 1 : 0
+
+  kind = "ingress-gateway"
+  name = "hashicups-ingress"
+
+  config_json = jsonencode({
+    Listeners = [{
+      Port     = 80
+      Protocol = "http"
+      Services = [
+        {
+          Name  = "frontend"
+          Hosts = ["*"]
+        }
+      ]
+    }]
+  })
+
+  depends_on = [consul_config_entry.service_default_frontend]
+}
+
+# All HashiCups service defaults
+# https://github.com/hashicorp/nomad/issues/8647#issuecomment-785484553
+resource "consul_config_entry" "service_default_public_api" {
+  count = var.install_demo_app ? 1 : 0
+
+  name = "public-api"
+  kind = "service-defaults"
+
+  config_json = jsonencode({
+    Protocol = "http"
+  })
+}
+
+resource "consul_config_entry" "service_default_payment_api" {
+  count = var.install_demo_app ? 1 : 0
+
+  name = "payment-api"
+  kind = "service-defaults"
+
+  config_json = jsonencode({
+    Protocol = "http"
+  })
+}
+
+resource "consul_config_entry" "service_default_product_api" {
+  count = var.install_demo_app ? 1 : 0
+
+  name = "product-api"
+  kind = "service-defaults"
+
+  config_json = jsonencode({
+    Protocol = "http"
+  })
+}
+
+resource "consul_config_entry" "service_default_product_db" {
+  count = var.install_demo_app ? 1 : 0
+
+  name = "product-db"
   kind = "service-defaults"
 
   config_json = jsonencode({

--- a/modules/hcp-ec2-client/services.tf
+++ b/modules/hcp-ec2-client/services.tf
@@ -1,19 +1,6 @@
 # This is needed for a tutorial on blue green deployments.
 # This helps show the functionality to make it happen and 
 # hide some of the complexity like service defaults
-resource "consul_config_entry" "proxy_defaults" {
-  count = var.install_demo_app ? 1 : 0
-
-  name = "global"
-  kind = "proxy-defaults"
-
-  config_json = jsonencode({
-    Config = {
-      protocol = "http"
-    }
-  })
-}
-
 resource "consul_config_entry" "service_default_frontend" {
   count = var.install_demo_app ? 1 : 0
 
@@ -49,50 +36,4 @@ resource "consul_config_entry" "ingress_gateway" {
   })
 
   depends_on = [consul_config_entry.service_default_frontend]
-}
-
-# All HashiCups service defaults
-# https://github.com/hashicorp/nomad/issues/8647#issuecomment-785484553
-resource "consul_config_entry" "service_default_public_api" {
-  count = var.install_demo_app ? 1 : 0
-
-  name = "public-api"
-  kind = "service-defaults"
-
-  config_json = jsonencode({
-    Protocol = "http"
-  })
-}
-
-resource "consul_config_entry" "service_default_payment_api" {
-  count = var.install_demo_app ? 1 : 0
-
-  name = "payment-api"
-  kind = "service-defaults"
-
-  config_json = jsonencode({
-    Protocol = "http"
-  })
-}
-
-resource "consul_config_entry" "service_default_product_api" {
-  count = var.install_demo_app ? 1 : 0
-
-  name = "product-api"
-  kind = "service-defaults"
-
-  config_json = jsonencode({
-    Protocol = "http"
-  })
-}
-
-resource "consul_config_entry" "service_default_product_db" {
-  count = var.install_demo_app ? 1 : 0
-
-  name = "product-db"
-  kind = "service-defaults"
-
-  config_json = jsonencode({
-    Protocol = "http"
-  })
 }

--- a/modules/hcp-ec2-client/templates/hashicups-frontend-v2.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups-frontend-v2.nomad
@@ -38,6 +38,10 @@ job "hashicups_frontend" {
       connect {
         sidecar_service {
           proxy {
+            config {
+              protocol = "http"
+            }
+
             upstreams {
               destination_name = "public-api"
               local_bind_port  = var.public_api_port

--- a/modules/hcp-ec2-client/templates/hashicups-frontend-v2.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups-frontend-v2.nomad
@@ -38,10 +38,6 @@ job "hashicups_frontend" {
       connect {
         sidecar_service {
           proxy {
-            config {
-              protocol = "http"
-            }
-
             upstreams {
               destination_name = "public-api"
               local_bind_port  = var.public_api_port
@@ -112,8 +108,8 @@ job "hashicups_frontend" {
 
       restart {
         interval = "30m"
-        attempts = 10
-        delay    = "15s"
+        attempts = 15
+        delay    = "30s"
         mode     = "fail"
       }
     }

--- a/modules/hcp-ec2-client/templates/hashicups-frontend-v2.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups-frontend-v2.nomad
@@ -105,13 +105,13 @@ job "hashicups_frontend" {
             }
           EOF
       }
+    }
 
-      restart {
-        interval = "30m"
-        attempts = 15
-        delay    = "30s"
-        mode     = "fail"
-      }
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 }

--- a/modules/hcp-ec2-client/templates/hashicups-frontend.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups-frontend.nomad
@@ -38,6 +38,10 @@ job "hashicups_frontend" {
       connect {
         sidecar_service {
           proxy {
+            config {
+              protocol = "http"
+            }
+
             upstreams {
               destination_name = "public-api"
               local_bind_port  = var.public_api_port

--- a/modules/hcp-ec2-client/templates/hashicups-frontend.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups-frontend.nomad
@@ -106,13 +106,13 @@ job "hashicups_frontend" {
             }
           EOF
       }
+    }
 
-      restart {
-        interval = "30m"
-        attempts = 15
-        delay    = "30s"
-        mode     = "fail"
-      }
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 }

--- a/modules/hcp-ec2-client/templates/hashicups-frontend.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups-frontend.nomad
@@ -38,10 +38,6 @@ job "hashicups_frontend" {
       connect {
         sidecar_service {
           proxy {
-            config {
-              protocol = "http"
-            }
-
             upstreams {
               destination_name = "public-api"
               local_bind_port  = var.public_api_port
@@ -113,8 +109,8 @@ job "hashicups_frontend" {
 
       restart {
         interval = "30m"
-        attempts = 10
-        delay    = "15s"
+        attempts = 15
+        delay    = "30s"
         mode     = "fail"
       }
     }

--- a/modules/hcp-ec2-client/templates/hashicups.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups.nomad
@@ -1,13 +1,3 @@
-variable "frontend_port" {
-  type    = number
-  default = 3000
-}
-
-variable "nginx_port" {
-  type    = number
-  default = 80
-}
-
 variable "public_api_port" {
   type    = number
   default = 7070
@@ -47,6 +37,10 @@ job "hashicups" {
       connect {
         sidecar_service {
           proxy {
+            config {
+              protocol = "http"
+            }
+
             upstreams {
               destination_name = "product-api"
               local_bind_port  = var.product_api_port
@@ -103,7 +97,13 @@ job "hashicups" {
       port = "http"
 
       connect {
-        sidecar_service {}
+        sidecar_service {
+          proxy {
+            config {
+              protocol = "http"
+            }
+          }
+        }
       }
     }
 
@@ -158,6 +158,10 @@ job "hashicups" {
       connect {
         sidecar_service {
           proxy {
+            config {
+              protocol = "http"
+            }
+
             upstreams {
               destination_name = "product-db"
               local_bind_port  = var.product_db_port
@@ -207,7 +211,13 @@ job "hashicups" {
       port = "http"
 
       connect {
-        sidecar_service {}
+        sidecar_service {
+          proxy {
+            config {
+              protocol = "http"
+            }
+          }
+        }
       }
     }
 

--- a/modules/hcp-ec2-client/templates/hashicups.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups.nomad
@@ -37,10 +37,6 @@ job "hashicups" {
       connect {
         sidecar_service {
           proxy {
-            config {
-              protocol = "http"
-            }
-
             upstreams {
               destination_name = "product-api"
               local_bind_port  = var.product_api_port
@@ -76,8 +72,8 @@ job "hashicups" {
 
       restart {
         interval = "30m"
-        attempts = 10
-        delay    = "15s"
+        attempts = 15
+        delay    = "30s"
         mode     = "fail"
       }
     }
@@ -99,9 +95,6 @@ job "hashicups" {
       connect {
         sidecar_service {
           proxy {
-            config {
-              protocol = "http"
-            }
           }
         }
       }
@@ -122,8 +115,8 @@ job "hashicups" {
 
       restart {
         interval = "30m"
-        attempts = 10
-        delay    = "15s"
+        attempts = 15
+        delay    = "30s"
         mode     = "fail"
       }
     }
@@ -158,10 +151,6 @@ job "hashicups" {
       connect {
         sidecar_service {
           proxy {
-            config {
-              protocol = "http"
-            }
-
             upstreams {
               destination_name = "product-db"
               local_bind_port  = var.product_db_port
@@ -190,8 +179,8 @@ job "hashicups" {
 
       restart {
         interval = "30m"
-        attempts = 10
-        delay    = "15s"
+        attempts = 15
+        delay    = "30s"
         mode     = "fail"
       }
     }
@@ -213,9 +202,6 @@ job "hashicups" {
       connect {
         sidecar_service {
           proxy {
-            config {
-              protocol = "http"
-            }
           }
         }
       }
@@ -242,8 +228,8 @@ job "hashicups" {
 
       restart {
         interval = "30m"
-        attempts = 10
-        delay    = "15s"
+        attempts = 15
+        delay    = "30s"
         mode     = "fail"
       }
     }

--- a/modules/hcp-ec2-client/templates/hashicups.nomad
+++ b/modules/hcp-ec2-client/templates/hashicups.nomad
@@ -69,13 +69,13 @@ job "hashicups" {
         PRODUCT_API_URI = "http://localhost:${var.product_api_port}"
         PAYMENT_API_URI = "http://localhost:${var.payment_api_port}"
       }
+    }
 
-      restart {
-        interval = "30m"
-        attempts = 15
-        delay    = "30s"
-        mode     = "fail"
-      }
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 
@@ -112,13 +112,13 @@ job "hashicups" {
         image = "hashicorpdemoapp/payments:v0.0.16"
         ports = ["http"]
       }
+    }
 
-      restart {
-        interval = "30m"
-        attempts = 15
-        delay    = "30s"
-        mode     = "fail"
-      }
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 
@@ -176,13 +176,13 @@ job "hashicups" {
         DB_CONNECTION = "host=localhost port=${var.product_db_port} user=postgres password=password dbname=products sslmode=disable"
         BIND_ADDRESS  = "localhost:${var.product_api_port}"
       }
+    }
 
-      restart {
-        interval = "30m"
-        attempts = 15
-        delay    = "30s"
-        mode     = "fail"
-      }
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 
@@ -225,13 +225,13 @@ job "hashicups" {
         POSTGRES_USER     = "postgres"
         POSTGRES_PASSWORD = "password"
       }
+    }
 
-      restart {
-        interval = "30m"
-        attempts = 15
-        delay    = "30s"
-        mode     = "fail"
-      }
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 }

--- a/modules/hcp-ec2-client/templates/ingress.nomad
+++ b/modules/hcp-ec2-client/templates/ingress.nomad
@@ -7,7 +7,7 @@ job "ingress-demo" {
     network {
       mode = "bridge"
 
-      port "inbound" {
+      port "http" {
         static = 80
         to     = 80
       }
@@ -15,11 +15,15 @@ job "ingress-demo" {
 
     service {
       name = "hashicups-ingress"
-      port = "80"
+      port = "http"
 
       connect {
         gateway {
-          proxy {}
+          proxy {
+            config {
+              protocol = "http"
+            }
+          }
 
           ingress {
             listener {

--- a/modules/hcp-ec2-client/templates/ingress.nomad
+++ b/modules/hcp-ec2-client/templates/ingress.nomad
@@ -20,9 +20,6 @@ job "ingress-demo" {
       connect {
         gateway {
           proxy {
-            config {
-              protocol = "http"
-            }
           }
 
           ingress {

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -31,9 +31,9 @@ variable "install_demo_app" {
   description = "Choose to install the demo app"
 }
 
-variable "igw_id" {
-  type        = string
-  description = "The ID of the VPC's Internet Gateway. Here to ensure the instance is deleted and public IP freed before attempting to destroy the Internet Gateway which will otherwise fail"
+variable "nat_public_ips" {
+  type        = list(string)
+  description = "Here to ensure the instance is deleted and public IP freed before attempting to destroy the Internet Gateway which will otherwise fail"
 }
 
 variable "node_id" {

--- a/modules/hcp-ecs-client/main.tf
+++ b/modules/hcp-ecs-client/main.tf
@@ -41,7 +41,7 @@ resource "aws_ecs_cluster" "clients" {
   name               = "hcp-ecs-cluster-${random_id.id.dec}"
   capacity_providers = ["FARGATE"]
 
-  depends_on = [var.igw_id]
+  depends_on = [var.nat_public_ips]
 }
 
 resource "random_id" "id" {

--- a/modules/hcp-ecs-client/variables.tf
+++ b/modules/hcp-ecs-client/variables.tf
@@ -30,9 +30,9 @@ variable "client_config_file" {
   description = "The client config file provided by HCP"
 }
 
-variable "igw_id" {
-  type        = string
-  description = "The ID of the VPC's Internet Gateway. Here to ensure the cluster and IP are freed before attempting to destroy the Internet Gateway which will otherwise fail"
+variable "nat_public_ips" {
+  type        = list(string)
+  description = "Here to ensure the cluster is deleted and public IP freed before attempting to destroy the Internet Gateway which will otherwise fail"
 }
 
 variable "client_ca_file" {

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.8\.6"
-new=0.8.7
+old="0\.8\.7"
+new=0.8.8
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -73,7 +73,7 @@ resource "aws_key_pair" "hcp_ec2" {
   count = local.ssh ? 1 : 0
 
   public_key = tls_private_key.ssh.public_key_openssh
-  key_name   = "hcp-ec2-key"
+  key_name   = "hcp-ec2-key-${local.cluster_id}"
 }
 
 resource "local_file" "ssh_key" {
@@ -86,14 +86,14 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -88,7 +88,7 @@ resource "aws_key_pair" "hcp_ec2" {
   count = local.ssh ? 1 : 0
 
   public_key = tls_private_key.ssh.public_key_openssh
-  key_name   = "hcp-ec2-key"
+  key_name   = "hcp-ec2-key-${local.cluster_id}"
 }
 
 resource "local_file" "ssh_key" {
@@ -101,14 +101,14 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -77,7 +77,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -92,7 +92,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-  igw_id                   = module.vpc.igw_id
+  nat_public_ips           = module.vpc.nat_public_ips
   private_subnet_ids       = module.vpc.private_subnets
   public_subnet_ids        = module.vpc.public_subnets
   region                   = local.vpc_region

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -109,7 +109,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn                = hcp_hvn.main
   vpc_id             = local.vpc_id
@@ -131,7 +131,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -151,7 +151,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   depends_on = [module.eks_consul_client]
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -126,7 +126,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   hvn                = hcp_hvn.main
   vpc_id             = module.vpc.vpc_id
@@ -148,7 +148,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
   cluster_id            = hcp_consul_cluster.main.cluster_id
@@ -168,7 +168,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.8.7"
+  version = "~> 0.8.8"
 
   depends_on = [module.eks_consul_client]
 }


### PR DESCRIPTION
- move nomad restarts into the Group level so they also cover failed Connect sidecars
- make the SSH keyname unique to the cluster
- predefined the protocol of the ingress gateway to avoid occasional delete failures:

```
# Unforunately, we have to pre-register the Ingress Gateway in Consul before
# the Nomad service starts (for now). Otherwise, destroys will fail with:
# "frontend" has protocol "tcp", which does not match defined listener protocol "http")
# https://github.com/hashicorp/nomad/issues/8647#issuecomment-785484553
resource "consul_config_entry" "ingress_gateway" {
  count = var.install_demo_app ? 1 : 0

  kind = "ingress-gateway"
  name = "hashicups-ingress"

  config_json = jsonencode({
    Listeners = [{
      Port     = 80
      Protocol = "http"
      Services = [
        {
          Name  = "frontend"
          Hosts = ["*"]
        }
      ]
    }]
  })

  depends_on = [consul_config_entry.service_default_frontend]
}
```