### PR TITLE
Fix Terraform output for Consul token shell export

### DIFF
--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -32,7 +32,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   To connect to the ec2 instance deployed: 
 ${var.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}

--- a/examples/hcp-eks-demo/output.tf
+++ b/examples/hcp-eks-demo/output.tf
@@ -34,7 +34,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   ${var.install_eks_cluster ? "You can access your provisioned eks cluster by first running following command" : ""}
   ${var.install_eks_cluster ? "export KUBECONFIG=$(terraform output -raw kubeconfig_filename)" : ""}    

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -136,7 +136,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   To connect to the ec2 instance deployed: 
 ${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -151,7 +151,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   To connect to the ec2 instance deployed: 
 ${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -191,7 +191,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   ${local.install_eks_cluster ? "You can access your provisioned eks cluster by first running following command" : ""}
   ${local.install_eks_cluster ? "export KUBECONFIG=$(terraform output -raw kubeconfig_filename)" : ""}    

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -208,7 +208,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   ${local.install_eks_cluster ? "You can access your provisioned eks cluster by first running following command" : ""}
   ${local.install_eks_cluster ? "export KUBECONFIG=$(terraform output -raw kubeconfig_filename)" : ""}    

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -136,7 +136,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   To connect to the ec2 instance deployed: 
 ${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -151,7 +151,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   To connect to the ec2 instance deployed: 
 ${local.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -191,7 +191,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   ${local.install_eks_cluster ? "You can access your provisioned eks cluster by first running following command" : ""}
   ${local.install_eks_cluster ? "export KUBECONFIG=$(terraform output -raw kubeconfig_filename)" : ""}    

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -208,7 +208,7 @@ output "howto_connect" {
 
   To access Consul from your local client run:
   export CONSUL_HTTP_ADDR="${hcp_consul_cluster.main.consul_public_endpoint_url}"
-  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
+  export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
   
   ${local.install_eks_cluster ? "You can access your provisioned eks cluster by first running following command" : ""}
   ${local.install_eks_cluster ? "export KUBECONFIG=$(terraform output -raw kubeconfig_filename)" : ""}    


### PR DESCRIPTION
Currently the instructions for setting the `CONSUL_HTTP_TOKEN` environment variable do not work out of the box, at least on ZSH `zsh 5.8.1 (x86_64-apple-darwin21.0)`.

Here's the current state after a Terraform apply of a Consul in a new VPC on EKS:

```shell-script
Apply complete! Resources: 91 added, 0 changed, 0 destroyed.

Outputs:

consul_root_token = <sensitive>
consul_url = "https://REDACTED.aws.hashicorp.cloud"
hashicups_url = "http://REDACTED.eu-central-1.elb.amazonaws.com"
helm_values_filename = "/REDACTED/helm_values_consul-quickstart-REDACTED"
howto_connect = <<EOT
  The demo app, HashiCups, Has been installed for you and its components registered in Consul.
  To access HashiCups navigate to: http://REDACTED.eu-central-1.elb.amazonaws.com

  To access Consul from your local client run:
  export CONSUL_HTTP_ADDR="https://REDACTED.aws.hashicorp.cloud"
  export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)

  You can access your provisioned eks cluster by first running following command
  export KUBECONFIG=$(terraform output -raw kubeconfig_filename)

  Consul has been installed in the default namespace. To explore what has been installed run:

  kubectl get pods


EOT
kubeconfig_filename = "/Users/krastin/workspace/canary/kubeconfig_consul-quickstart-REDACTED-eks"
next_steps = "HashiCups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."





[krastin:~/workspace/canary] [system] % export CONSUL_HTTP_ADDR="https://consul-quickstart-REDACTED.aws.hashicorp.cloud"
[krastin:~/workspace/canary] [system] % export CONSUL_HTTP_TOKEN=$(terraform output consul_root_token)
[krastin:~/workspace/canary] [system] % consul members
Error retrieving members: Unexpected response code: 403 (ACL not found)
[krastin:~/workspace/canary] [system] 1 % env | grep -i consul
CONSUL_HTTP_ADDR=https://consul-quickstart-REDACTED.aws.hashicorp.cloud
CONSUL_HTTP_TOKEN="ff6790de-c22f-766a-9af4-REDACTED"
KUBECONFIG=/Users/krastin/workspace/canary/kubeconfig_consul-quickstart-REDACTED-eks
[krastin:~/workspace/canary] [system] % consul version
Consul v1.13.0
Build Date 1970-01-01T00:00:01Z
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)

[krastin:~/workspace/canary] [system] % consul members -token 'ff6790de-c22f-766a-9af4-REDACTED'
Node                                         Address             Status  Type    Build       Protocol  DC                               Partition  Segment
ip-172-25-41-211                             172.25.41.211:8301  alive   server  1.13.2+ent  2         consul-quickstart-REDACTED  default    <all>
[...]
[krastin:~/workspace/canary] [system] % export CONSUL_HTTP_TOKEN=$(terraform output -raw consul_root_token)
[krastin:~/workspace/canary] [system] % env | grep -i consul
CONSUL_HTTP_ADDR=https://consul-quickstart-REDACTED.aws.hashicorp.cloud
CONSUL_HTTP_TOKEN=ff6790de-c22f-766a-9af4-REDACTED
KUBECONFIG=/Users/krastin/workspace/canary/kubeconfig_consul-quickstart-REDACTED-eks
[krastin:~/workspace/canary] [system] % consul members
Node                                         Address             Status  Type    Build       Protocol  DC                               Partition  Segment
ip-172-25-41-211                             172.25.41.211:8301  alive   server  1.13.2+ent  2         consul-quickstart-REDACTED  default    <all>
[...]
```

Apparently `export CONSUL_HTTP_TOKEN="$(terraform output consul_root_token)"` in a shell results in 

```
[krastin:~/workspace/canary] [system] % env | grep -i consul
CONSUL_HTTP_TOKEN="ff6790de-c22f-766a-9af4-REDACTED"
```

While `export CONSUL_HTTP_TOKEN="$(terraform output -raw consul_root_token)"` in 

```
[krastin:~/workspace/canary] [system] % env | grep -i consul
CONSUL_HTTP_TOKEN=ff6790de-c22f-766a-9af4-REDACTED
```