### PR TITLE
fix HashiCups K8S deployment

### DIFF
--- a/modules/k8s-demo-app/main.tf
+++ b/modules/k8s-demo-app/main.tf
@@ -21,7 +21,7 @@ resource "kubectl_manifest" "applications" {
   # For some reason using the above line returns a count not known until apply
   # error, even though the files are static. This needs to be kept in sync with
   # the YAML files defined in the services/ directory.
-  count     = 34
+  count     = 35
   yaml_body = element(data.kubectl_path_documents.manifests.documents, count.index)
 }
 


### PR DESCRIPTION
The `public-api` resource is not deployed unless `count` is bumped up to 35.