### PR TITLE
Remove back quote from comment and bump release version

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -26,7 +26,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -67,7 +67,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -28,7 +28,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -49,7 +49,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -65,7 +65,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.9.0"
+#   version = "~> 0.9.1"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = module.vpc.vpc_id
@@ -88,11 +88,11 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
-  # strip out `https://` from the public url
+  # strip out url scheme from the public url
   consul_hosts     = tolist([substr(hcp_consul_cluster.main.consul_public_endpoint_url, 8, -1)])
   consul_version   = hcp_consul_cluster.main.consul_version
   datacenter       = hcp_consul_cluster.main.datacenter
@@ -107,7 +107,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = var.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -86,7 +86,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -101,7 +101,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -110,7 +110,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.9.0"
+#   version = "~> 0.9.1"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = local.vpc_id
@@ -133,11 +133,11 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
-  # strip out `https://` from the public url
+  # strip out url scheme from the public url
   consul_hosts     = tolist([substr(hcp_consul_cluster.main.consul_public_endpoint_url, 8, -1)])
   consul_version   = hcp_consul_cluster.main.consul_version
   datacenter       = hcp_consul_cluster.main.datacenter
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -128,7 +128,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.9.0"
+#   version = "~> 0.9.1"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = module.vpc.vpc_id
@@ -151,11 +151,11 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
-  # strip out `https://` from the public url
+  # strip out url scheme from the public url
   consul_hosts     = tolist([substr(hcp_consul_cluster.main.consul_public_endpoint_url, 8, -1)])
   consul_version   = hcp_consul_cluster.main.consul_version
   datacenter       = hcp_consul_cluster.main.datacenter
@@ -170,7 +170,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   depends_on = [module.eks_consul_client]
 }

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.8\.10"
-new=0.9.0
+old="0\.9\.0"
+new=0.9.1
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -86,7 +86,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -101,7 +101,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -45,7 +45,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -66,7 +66,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -60,7 +60,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -81,7 +81,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -110,7 +110,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.9.0"
+#   version = "~> 0.9.1"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = local.vpc_id
@@ -133,11 +133,11 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
-  # strip out `https://` from the public url
+  # strip out url scheme from the public url
   consul_hosts     = tolist([substr(hcp_consul_cluster.main.consul_public_endpoint_url, 8, -1)])
   consul_version   = hcp_consul_cluster.main.consul_version
   datacenter       = hcp_consul_cluster.main.datacenter
@@ -152,7 +152,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   depends_on = [module.eks_consul_client]
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -128,7 +128,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.9.0"
+#   version = "~> 0.9.1"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = module.vpc.vpc_id
@@ -151,11 +151,11 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
-  # strip out `https://` from the public url
+  # strip out url scheme from the public url
   consul_hosts     = tolist([substr(hcp_consul_cluster.main.consul_public_endpoint_url, 8, -1)])
   consul_version   = hcp_consul_cluster.main.consul_version
   datacenter       = hcp_consul_cluster.main.datacenter
@@ -170,7 +170,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.9.0"
+  version = "~> 0.9.1"
 
   depends_on = [module.eks_consul_client]
 }


### PR DESCRIPTION
Removes back quote from a comment which caused an error on template generation on HCP UI side.