### PR TITLE
Fix EC2 and ECS client's `nat_public_ips` parameter for existing VPC UI templates

### DIFF
--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -93,6 +93,7 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
+  nat_public_ips           = []
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -93,7 +93,6 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
-  nat_public_ips           = module.vpc.nat_public_ips
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -77,6 +77,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  nat_public_ips           = []
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -77,7 +77,6 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-  nat_public_ips           = module.vpc.nat_public_ips
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region

--- a/modules/hcp-ec2-client/variables.tf
+++ b/modules/hcp-ec2-client/variables.tf
@@ -33,7 +33,7 @@ variable "install_demo_app" {
 
 variable "nat_public_ips" {
   type        = list(string)
-  description = "Here to ensure the instance is deleted and public IP freed before attempting to destroy the Internet Gateway which will otherwise fail"
+  description = "Here to ensure the instance is deleted and public IP freed before attempting to destroy the Internet Gateway which will otherwise fail. Note: this is only necessary for new VPCs"
 }
 
 variable "node_id" {

--- a/scripts/generate_ui_templates.sh
+++ b/scripts/generate_ui_templates.sh
@@ -14,7 +14,7 @@ generate_base_existing_vpc_terraform () {
     | sed -e 's/module\.vpc\.public_subnets\[0\]/local\.public_subnet1/' \
     | sed -e 's/module\.vpc\.public_route_table_ids/\[local\.public_route_table_id\]/' \
     | sed -e 's/module\.vpc\.private_route_table_ids/\[local\.private_route_table_id\]/' \
-    | sed -e '/module\.vpc\.nat_public_ips/d'
+    | sed -e 's/module\.vpc\.nat_public_ips/\[\]/'
 }
 
 generate_existing_vpc_terraform () {

--- a/scripts/generate_ui_templates.sh
+++ b/scripts/generate_ui_templates.sh
@@ -13,7 +13,8 @@ generate_base_existing_vpc_terraform () {
     | sed -e 's/module\.vpc\.vpc_id/local\.vpc_id/' \
     | sed -e 's/module\.vpc\.public_subnets\[0\]/local\.public_subnet1/' \
     | sed -e 's/module\.vpc\.public_route_table_ids/\[local\.public_route_table_id\]/' \
-    | sed -e 's/module\.vpc\.private_route_table_ids/\[local\.private_route_table_id\]/'
+    | sed -e 's/module\.vpc\.private_route_table_ids/\[local\.private_route_table_id\]/' \
+    | sed -e '/module\.vpc\.nat_public_ips/d'
 }
 
 generate_existing_vpc_terraform () {

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -93,6 +93,7 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
+  nat_public_ips           = []
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -93,7 +93,6 @@ module "aws_ec2_consul_client" {
   client_ca_file           = hcp_consul_cluster.main.consul_ca_file
   client_config_file       = hcp_consul_cluster.main.consul_config_file
   consul_version           = hcp_consul_cluster.main.consul_version
-  nat_public_ips           = module.vpc.nat_public_ips
   install_demo_app         = local.install_demo_app
   root_token               = hcp_consul_cluster_root_token.token.secret_id
   security_group_id        = module.aws_hcp_consul.security_group_id

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -77,6 +77,7 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
+  nat_public_ips           = []
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -77,7 +77,6 @@ module "aws_ecs_cluster" {
   consul_url               = hcp_consul_cluster.main.consul_private_endpoint_url
   consul_version           = substr(hcp_consul_cluster.main.consul_version, 1, -1)
   datacenter               = hcp_consul_cluster.main.datacenter
-  nat_public_ips           = module.vpc.nat_public_ips
   private_subnet_ids       = [local.private_subnet1, local.private_subnet2]
   public_subnet_ids        = [local.public_subnet1, local.public_subnet2]
   region                   = local.vpc_region


### PR DESCRIPTION
### Context/Background

There's a bugged variable reference to `module.vpc.nat_public_ips`s which will fail for existing VPCs. For existing VPCs, we don't use the VPC module to make a VPC.

Arian Cabrera shared this with me to reproduce:

```
Follow the steps in the guide https://developer.hashicorp.com/consul/tutorials/cloud-deploy-automation/consul-end-to-end-ec2#vpc_id
* Using an existing VPC
* Provide necesary data
* copy generated Terraform code
* When performing terraform plan you should get the following error
terraform plan
╷
│ Error: Reference to undeclared module
│
│   on main.tf line 96, in module “aws_ec2_consul_client”:
│   96:   nat_public_ips           = module.vpc.nat_public_ips
│
│ No module call named “vpc” is declared in the root module.
```

### Change

The change here is to remove the reference to `module.vpc` in existing VPC UI templates, as we do for other `module.vpc` variables:

```
    | sed -e 's/module\.vpc\.nat_public_ips/\[\]/'
```

### Deployment

There will need to a be a frontend patch for this. This does not require a new TF provider release, as nothing about the TF provider changed

### Testing

I took the UI template for EC2, replaced the `nat_public_ips` variable with an empty array, and was able to `tf apply` w/o error.