### PR TITLE
Fix EC2 example and set WorkingDirectory for systemd service

### DIFF
--- a/examples/hcp-ec2-demo/output.tf
+++ b/examples/hcp-ec2-demo/output.tf
@@ -20,7 +20,7 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = local.install_demo_app ? "HashiCups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token." : null
+  value = var.install_demo_app ? "HashiCups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token." : null
 }
 
 output "howto_connect" {
@@ -36,6 +36,6 @@ output "howto_connect" {
   
   To connect to the ec2 instance deployed: 
 ${var.ssh ? "  - To access via SSH run: ssh -i ${abspath(local_file.ssh_key[0].filename)} ubuntu@${module.aws_ec2_consul_client.public_ip}" : ""}
-${var.ssm ? "  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${local.vpc_region}" : ""}
+${var.ssm ? "  - To access via SSM run: aws ssm start-session --target ${module.aws_ec2_consul_client.host_id} --region ${var.vpc_region}" : ""}
   EOF
 }

--- a/modules/hcp-ec2-client/templates/service
+++ b/modules/hcp-ec2-client/templates/service
@@ -12,6 +12,7 @@ KillMode=process
 KillSignal=SIGTERM
 Restart=on-failure
 LimitNOFILE=65536
+WorkingDirectory=/etc/consul.d/
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With Consul 1.14.0+, we set the new `tls.defaults` settings in Consul configuration. Because the client config uses relative paths when downloaded from HCP, the consul service was unable to start up. This PR also fixes invalid `local` references in the examples terraform.

```
Jan 10 14:29:44 ip-10-0-1-226 consul[84162]: ==> Error loading from ./ca.pem: open ./ca.pem: no such file or directory
Jan 10 14:29:44 ip-10-0-1-226 systemd[1]: consul.service: Main process exited, code=exited, status=1/FAILURE
Jan 10 14:29:44 ip-10-0-1-226 systemd[1]: consul.service: Failed with result 'exit-code'.
Jan 10 14:29:44 ip-10-0-1-226 systemd[1]: consul.service: Scheduled restart job, restart counter is at 5.
```

By setting `WorkingDirectory` in the systemd service file ([ref](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#WorkingDirectory=)), we can use relative paths from the client config without modifying them.

Screenshots after modifying the service file:

<img width="731" alt="Screen Shot 2023-01-10 at 9 26 39 AM" src="https://user-images.githubusercontent.com/4146455/211578818-5c6dacb5-5a0f-4f48-9219-7f7a70cc9aaa.png">

<img width="704" alt="Screen Shot 2023-01-10 at 9 26 19 AM" src="https://user-images.githubusercontent.com/4146455/211578812-fe94c915-ff7f-432a-b6c1-6461bf0eb449.png">
