### PR TITLE
Update public-api.yaml

### DIFF
--- a/modules/k8s-demo-app/services/public-api.yaml
+++ b/modules/k8s-demo-app/services/public-api.yaml
@@ -45,7 +45,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9102"
         consul.hashicorp.com/connect-inject: "true"
-        consul.hashicorp.com/connect-service-upstreams: "product-api:9090, payments:1800"
     spec:
       serviceAccountName: public-api
       containers:


### PR DESCRIPTION
Remove annotation since tProxy is enabled. 

With tproxy, you can refer to "http://product-api:9090" or even "http://product-api" since tProxy drops the port.

Without the explicit definition consul.hashicorp.com/connect-service-upstreams: "product-api:9090". But then we don't use the bound upstream in these lines (https://github.com/hashicorp/terraform-aws-hcp-consul/blob/main/modules/k8s-demo-app/services/public-api.yaml#L60-L63) , because it's referring to a dns name and not localhost.

Once this has been merged we will need to bump the module versions and regenerate the templates. 