### PR TITLE
Updating ECS services modules from 0.2.0 to 0.6.0

### DIFF
--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -3,23 +3,24 @@
 
 module "acl-controller" {
   source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
-  version = "0.4.2"
+  version = "0.6.0"
 
   log_configuration = {
     logDriver = "awslogs"
     options = {
       awslogs-group         = aws_cloudwatch_log_group.log_group.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "consul-acl-controller"
+      awslogs-stream-prefix = "consul-acl-controller-hcp"
     }
   }
 
   consul_server_http_addr           = var.consul_url
   consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
+  consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
   ecs_cluster_arn                   = aws_ecs_cluster.clients.arn
   region                            = var.region
   subnets                           = var.private_subnet_ids
-
+  #security_groups = [aws_security_group.disney_sg.id]
   name_prefix = local.secret_prefix
 }
 
@@ -59,7 +60,7 @@ resource "aws_iam_role" "frontend-execution-role" {
 
 module "frontend" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.3.0"
+  version = "~> 0.6.0"
 
   family         = "frontend"
   task_role      = aws_iam_role.frontend-task-role
@@ -113,14 +114,16 @@ module "frontend" {
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
   consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
-
+  consul_partition               = "default"
+  consul_namespace               = "default"
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
-
+  consul_http_addr               = var.consul_url
+  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
-  consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  acl_secret_name_prefix         = local.secret_prefix
+  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
+  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "frontend" {
@@ -181,7 +184,7 @@ resource "aws_iam_role" "public-api-execution-role" {
 
 module "public-api" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.3.0"
+  version = "~> 0.6.0"
 
   family         = "public-api"
   task_role      = aws_iam_role.public-api-task-role
@@ -254,14 +257,16 @@ module "public-api" {
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
   consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
-
+  consul_partition               = "default"
+  consul_namespace               = "default"
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
-
+  consul_http_addr               = var.consul_url
+  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
-  consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  acl_secret_name_prefix         = local.secret_prefix
+  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
+  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "public-api" {
@@ -322,7 +327,7 @@ resource "aws_iam_role" "payment-api-execution-role" {
 
 module "payment-api" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.3.0"
+  version = "~> 0.6.0"
 
   family         = "payment-api"
   task_role      = aws_iam_role.payment-api-task-role
@@ -365,17 +370,20 @@ module "payment-api" {
 
   port = local.payment_api_port
 
+  
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
   consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
-
+  consul_partition               = "default"
+  consul_namespace               = "default"
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
-
+  consul_http_addr               = var.consul_url
+  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
-  consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  acl_secret_name_prefix         = local.secret_prefix
+  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
+  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "payment-api" {
@@ -430,7 +438,7 @@ resource "aws_iam_role" "product-api-execution-role" {
 
 module "product-api" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.3.0"
+  version = "~> 0.6.0"
 
   family         = "product-api"
   task_role      = aws_iam_role.product-api-task-role
@@ -490,17 +498,20 @@ module "product-api" {
 
   port = local.product_api_port
 
+  
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
   consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
-
+  consul_partition               = "default"
+  consul_namespace               = "default"
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
-
+  consul_http_addr               = var.consul_url
+  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
-  consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  acl_secret_name_prefix         = local.secret_prefix
+  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
+  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "product-api" {
@@ -555,7 +566,7 @@ resource "aws_iam_role" "product-db-execution-role" {
 
 module "product-db" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
-  version = "~> 0.3.0"
+  version = "~> 0.6.0"
 
   family         = "product-db"
   task_role      = aws_iam_role.product-db-task-role
@@ -612,17 +623,20 @@ module "product-db" {
 
   port = local.product_db_port
 
+  
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
   consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
-
+  consul_partition               = "default"
+  consul_namespace               = "default"
   tls                       = true
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
-
+  consul_http_addr               = var.consul_url
+  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
-  consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  acl_secret_name_prefix         = local.secret_prefix
+  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
+  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "product-db" {

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -14,6 +14,8 @@ module "acl-controller" {
     }
   }
 
+  #consul_http_addr               = var.consul_url
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   consul_server_http_addr           = var.consul_url
   consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
   consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -115,7 +115,7 @@ module "frontend" {
 
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
-  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
+  consul_image      = "public.ecr.aws/hashicorp/consul-enterprise:${var.consul_version}-ent"
   consul_partition               = "default"
   consul_namespace               = "default"
   tls                       = true
@@ -258,7 +258,7 @@ module "public-api" {
 
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
-  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
+  consul_image      = "public.ecr.aws/hashicorp/consul-enterprise:${var.consul_version}-ent"
   consul_partition               = "default"
   consul_namespace               = "default"
   tls                       = true
@@ -375,7 +375,7 @@ module "payment-api" {
   
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
-  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
+  consul_image      = "public.ecr.aws/hashicorp/consul-enterprise:${var.consul_version}-ent"
   consul_partition               = "default"
   consul_namespace               = "default"
   tls                       = true
@@ -503,7 +503,7 @@ module "product-api" {
   
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
-  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
+  consul_image      = "public.ecr.aws/hashicorp/consul-enterprise:${var.consul_version}-ent"
   consul_partition               = "default"
   consul_namespace               = "default"
   tls                       = true
@@ -628,7 +628,7 @@ module "product-db" {
   
   retry_join        = var.client_retry_join
   consul_datacenter = var.datacenter
-  consul_image      = "public.ecr.aws/hashicorp/consul:${var.consul_version}"
+  consul_image      = "public.ecr.aws/hashicorp/consul-enterprise:${var.consul_version}-ent"
   consul_partition               = "default"
   consul_namespace               = "default"
   tls                       = true

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -14,15 +14,15 @@ module "acl-controller" {
     }
   }
 
-  consul_http_addr               = var.consul_url
-  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
-  #consul_server_http_addr           = var.consul_url
+  #consul_http_addr               = var.consul_url
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  consul_server_http_addr           = var.consul_url
   consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
-  #consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
+  consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
   ecs_cluster_arn                   = aws_ecs_cluster.clients.arn
   region                            = var.region
   subnets                           = var.private_subnet_ids
-  #security_groups = [aws_security_group.disney_sg.id]
+  security_groups = [var.security_group_id]
   name_prefix = local.secret_prefix
 }
 

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -18,7 +18,7 @@ module "acl-controller" {
   #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   consul_server_http_addr           = var.consul_url
   consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
-  consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
+  #consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
   ecs_cluster_arn                   = aws_ecs_cluster.clients.arn
   region                            = var.region
   subnets                           = var.private_subnet_ids

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -13,12 +13,9 @@ module "acl-controller" {
       awslogs-stream-prefix = "consul-acl-controller-hcp"
     }
   }
-
-  #consul_http_addr               = var.consul_url
-  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   consul_server_http_addr           = var.consul_url
   consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
-  #consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
+  #consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn #Do not configure for HCP
   ecs_cluster_arn                   = aws_ecs_cluster.clients.arn
   region                            = var.region
   subnets                           = var.private_subnet_ids
@@ -122,10 +119,8 @@ module "frontend" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn #Do not configure for HCP
   acls                           = true
-  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "frontend" {
@@ -265,10 +260,8 @@ module "public-api" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
- #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+ #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn #Do not configure for HCP
   acls                           = true
-  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "public-api" {
@@ -382,10 +375,8 @@ module "payment-api" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn #Do not configure for HCP
   acls                           = true
-  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "payment-api" {
@@ -510,10 +501,8 @@ module "product-api" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn #Do not configure for HCP
   acls                           = true
-  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "product-api" {
@@ -635,10 +624,8 @@ module "product-db" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn #Do not configure for HCP
   acls                           = true
-  #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
-  #acl_secret_name_prefix         = local.secret_prefix
 }
 
 resource "aws_ecs_service" "product-db" {

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -122,7 +122,7 @@ module "frontend" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
   #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
   #acl_secret_name_prefix         = local.secret_prefix
@@ -265,7 +265,7 @@ module "public-api" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+ #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
   #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
   #acl_secret_name_prefix         = local.secret_prefix
@@ -382,7 +382,7 @@ module "payment-api" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
   #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
   #acl_secret_name_prefix         = local.secret_prefix
@@ -510,7 +510,7 @@ module "product-api" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
   #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
   #acl_secret_name_prefix         = local.secret_prefix
@@ -635,7 +635,7 @@ module "product-db" {
   consul_server_ca_cert_arn = aws_secretsmanager_secret.ca_cert.arn
   gossip_key_secret_arn     = aws_secretsmanager_secret.gossip_key.arn
   consul_http_addr               = var.consul_url
-  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
   acls                           = true
   #consul_client_token_secret_arn = module.acl-controller.client_token_secret_arn
   #acl_secret_name_prefix         = local.secret_prefix

--- a/modules/hcp-ecs-client/services.tf
+++ b/modules/hcp-ecs-client/services.tf
@@ -14,11 +14,11 @@ module "acl-controller" {
     }
   }
 
-  #consul_http_addr               = var.consul_url
-  #consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
-  consul_server_http_addr           = var.consul_url
+  consul_http_addr               = var.consul_url
+  consul_https_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  #consul_server_http_addr           = var.consul_url
   consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
-  consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
+  #consul_server_ca_cert_arn         = aws_secretsmanager_secret.ca_cert.arn
   ecs_cluster_arn                   = aws_ecs_cluster.clients.arn
   region                            = var.region
   subnets                           = var.private_subnet_ids


### PR DESCRIPTION
Hi all - i needed this module for HCP+ECS but noticed compatibility issues because the ECS modules were at 0.2.0. I have tested these configurations multiple times using 0.6.0 (latest as of 04-17-2023) modules. I made a few suggestions that might be more opinionated as well, am open to discussion. Hope this helps. 