### PR TITLE
ec2 client module enhancements

### DIFF
--- a/examples/hcp-ec2-demo/main.tf
+++ b/examples/hcp-ec2-demo/main.tf
@@ -29,7 +29,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -66,7 +66,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -88,7 +88,7 @@ module "hashicups" {
   count = var.install_demo_app ? 1 : 0
 
   source  = "hashicorp/hcp-consul/aws//modules/ec2-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [
     module.aws_ec2_consul_client

--- a/examples/hcp-ecs-demo/main.tf
+++ b/examples/hcp-ecs-demo/main.tf
@@ -31,7 +31,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -52,7 +52,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/examples/hcp-eks-demo/main.tf
+++ b/examples/hcp-eks-demo/main.tf
@@ -68,7 +68,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.12.1"
+#   version = "~> 0.13.0"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = module.vpc.vpc_id
@@ -91,7 +91,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
@@ -110,7 +110,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = var.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -51,7 +51,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -88,7 +88,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -110,7 +110,7 @@ module "hashicups" {
   count = local.install_demo_app ? 1 : 0
 
   source  = "hashicorp/hcp-consul/aws//modules/ec2-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [
     module.aws_ec2_consul_client

--- a/hcp-ui-templates/ec2/main.tf
+++ b/hcp-ui-templates/ec2/main.tf
@@ -66,7 +66,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -103,7 +103,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -125,7 +125,7 @@ module "hashicups" {
   count = local.install_demo_app ? 1 : 0
 
   source  = "hashicorp/hcp-consul/aws//modules/ec2-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [
     module.aws_ec2_consul_client

--- a/hcp-ui-templates/ecs-existing-vpc/main.tf
+++ b/hcp-ui-templates/ecs-existing-vpc/main.tf
@@ -47,7 +47,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -68,7 +68,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/ecs/main.tf
+++ b/hcp-ui-templates/ecs/main.tf
@@ -62,7 +62,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -83,7 +83,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/hcp-ui-templates/eks-existing-vpc/main.tf
+++ b/hcp-ui-templates/eks-existing-vpc/main.tf
@@ -112,7 +112,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.12.1"
+#   version = "~> 0.13.0"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = local.vpc_id
@@ -135,7 +135,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
@@ -154,7 +154,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [module.eks_consul_client]
 }

--- a/hcp-ui-templates/eks/main.tf
+++ b/hcp-ui-templates/eks/main.tf
@@ -130,7 +130,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.12.1"
+#   version = "~> 0.13.0"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = module.vpc.vpc_id
@@ -153,7 +153,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
@@ -172,7 +172,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [module.eks_consul_client]
 }

--- a/modules/hcp-ec2-client/templates/setup.sh
+++ b/modules/hcp-ec2-client/templates/setup.sh
@@ -14,14 +14,18 @@ setup_deps () {
 	add-apt-repository universe -y
 
 	# Add HashiCorp repository
-  	curl -fSL --retry 3 https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+	curl -fSL --retry 3 https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
 	apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+	# test repo for release candidate versions
+	apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) test"
 	curl -L --retry 3 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
 	echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list
 	apt update -y
 
 	# Install Consul, Nomad, Envoy, and Nginx
-	version="${consul_version}"
+	# Note: apt is unable to find packages if '-rc*' is used. Hence trimming '-rc' from version which is present only in case
+	# of candidate release versions.
+	version=$(sed -r 's/-rc([0-9]*)//g'<<<${consul_version})
 	consul_package="consul-enterprise="$${version:1}"*"
 	apt install -y apt-transport-https gnupg2 curl lsb-release nomad $${consul_package} getenvoy-envoy unzip jq apache2-utils nginx
 

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-old="0\.12\.0"
-new=0.12.1
+old="0\.12\.1"
+new=0.13.0
 
 for platform in ec2 ecs eks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/ec2-existing-vpc.golden
+++ b/test/hcp/testdata/ec2-existing-vpc.golden
@@ -51,7 +51,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -88,7 +88,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -110,7 +110,7 @@ module "hashicups" {
   count = local.install_demo_app ? 1 : 0
 
   source  = "hashicorp/hcp-consul/aws//modules/ec2-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [
     module.aws_ec2_consul_client

--- a/test/hcp/testdata/ec2.golden
+++ b/test/hcp/testdata/ec2.golden
@@ -66,7 +66,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -103,7 +103,7 @@ resource "local_file" "ssh_key" {
 
 module "aws_ec2_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ec2-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]
@@ -125,7 +125,7 @@ module "hashicups" {
   count = local.install_demo_app ? 1 : 0
 
   source  = "hashicorp/hcp-consul/aws//modules/ec2-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [
     module.aws_ec2_consul_client

--- a/test/hcp/testdata/ecs-existing-vpc.golden
+++ b/test/hcp/testdata/ecs-existing-vpc.golden
@@ -47,7 +47,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = local.vpc_id
@@ -68,7 +68,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/ecs.golden
+++ b/test/hcp/testdata/ecs.golden
@@ -62,7 +62,7 @@ resource "hcp_hvn" "main" {
 
 module "aws_hcp_consul" {
   source  = "hashicorp/hcp-consul/aws"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   hvn             = hcp_hvn.main
   vpc_id          = module.vpc.vpc_id
@@ -83,7 +83,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "aws_ecs_cluster" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-ecs-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   allowed_http_cidr_blocks = ["0.0.0.0/0"]
   allowed_ssh_cidr_blocks  = ["0.0.0.0/0"]

--- a/test/hcp/testdata/eks-existing-vpc.golden
+++ b/test/hcp/testdata/eks-existing-vpc.golden
@@ -112,7 +112,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.12.1"
+#   version = "~> 0.13.0"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = local.vpc_id
@@ -135,7 +135,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
@@ -154,7 +154,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [module.eks_consul_client]
 }

--- a/test/hcp/testdata/eks.golden
+++ b/test/hcp/testdata/eks.golden
@@ -130,7 +130,7 @@ resource "hcp_hvn" "main" {
 # Note: Uncomment the below module to setup peering for connecting to a private HCP Consul cluster
 # module "aws_hcp_consul" {
 #   source  = "hashicorp/hcp-consul/aws"
-#   version = "~> 0.12.1"
+#   version = "~> 0.13.0"
 #
 #   hvn                = hcp_hvn.main
 #   vpc_id             = module.vpc.vpc_id
@@ -153,7 +153,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "eks_consul_client" {
   source  = "hashicorp/hcp-consul/aws//modules/hcp-eks-client"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   boostrap_acl_token = hcp_consul_cluster_root_token.token.secret_id
   cluster_id         = hcp_consul_cluster.main.cluster_id
@@ -172,7 +172,7 @@ module "eks_consul_client" {
 module "demo_app" {
   count   = local.install_demo_app ? 1 : 0
   source  = "hashicorp/hcp-consul/aws//modules/k8s-demo-app"
-  version = "~> 0.12.1"
+  version = "~> 0.13.0"
 
   depends_on = [module.eks_consul_client]
 }


### PR DESCRIPTION
Allow installing release candidate versions of Consul on the ec2 client node.

Related JIRA: https://hashicorp.atlassian.net/browse/CC-6563

Tested it by referencing changes to local ec2 module within the hcp-ec2-demo. (Missed capturing the terminal screenshot, but let me know if that is a blocker)